### PR TITLE
merge_all on get_tile fixed resolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
   - "3.6"
   - "nightly"
 
+branches:
+  only:
+  - master
+
 matrix:
   allow_failures:
   - python: "nightly"

--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -20,7 +20,7 @@ from telluric.plotting import NotebookPlottingMixin
 from telluric.rasterization import rasterize
 from telluric.vectors import GeoVector
 from telluric.features import GeoFeature
-from telluric.georaster import merge_all
+from telluric.georaster import merge_all, mercator_zoom_to_resolution
 
 DRIVERS = {
     '.json': 'GeoJSON',
@@ -226,6 +226,8 @@ class BaseCollection(Sequence, NotebookPlottingMixin):
                 new_feature = self._adapt_feature_before_write(feature)
                 sink.write(new_feature.to_record(crs))
 
+    executer = ThreadPoolExecutor(max_workers=MAX_WORKERS)
+
     def get_tile(self, x, y, z, sort_by=None, desc=False, bands=None):
         """Generate mercator tile from rasters in FeatureCollection.
 
@@ -259,10 +261,10 @@ class BaseCollection(Sequence, NotebookPlottingMixin):
         def _get_tiled_feature(feature):
             return feature.get_tiled_feature(x, y, z, bands)
 
-        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executer:
-            tiled_features = list(executer.map(_get_tiled_feature,
-                                               filtered_fc,
-                                               timeout=CONCURRENCY_TIMEOUT))
+        tiled_features = list(self.executer.map(_get_tiled_feature,
+                                                filtered_fc,
+                                                timeout=CONCURRENCY_TIMEOUT))
+        # tiled_features = list(_get_tiled_feature(f) for f in filtered_fc)
 
         # tiled_features can be sort for different merge strategies
         if sort_by is not None:
@@ -272,7 +274,8 @@ class BaseCollection(Sequence, NotebookPlottingMixin):
 
         tiles = [f['tile'] for f in tiled_features]
         if tiles:
-            tile = merge_all(tiles, roi)
+            resolution = mercator_zoom_to_resolution[z]
+            tile = merge_all(tiles, roi, dest_resolution=resolution)
             return tile
         else:
             return None

--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -264,7 +264,6 @@ class BaseCollection(Sequence, NotebookPlottingMixin):
         tiled_features = list(self.executer.map(_get_tiled_feature,
                                                 filtered_fc,
                                                 timeout=CONCURRENCY_TIMEOUT))
-        # tiled_features = list(_get_tiled_feature(f) for f in filtered_fc)
 
         # tiled_features can be sort for different merge strategies
         if sort_by is not None:

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -15,7 +15,7 @@ from telluric.constants import DEFAULT_CRS, WGS84_CRS, WEB_MERCATOR_CRS
 from telluric.vectors import GeoVector
 from telluric.features import GeoFeature
 from telluric.collections import FeatureCollection, FileCollection, FeatureCollectionIOError
-from telluric.georaster import GeoRaster2, merge_all
+from telluric.georaster import GeoRaster2, merge_all, mercator_zoom_to_resolution
 
 
 def fc_generator(num_features):
@@ -309,7 +309,9 @@ def test_get_tile_merge_tiles(tile):
     eroi = GeoVector.from_bounds(xmin=bounds.left, xmax=bounds.right,
                                  ymin=bounds.bottom, ymax=bounds.top,
                                  crs=WEB_MERCATOR_CRS)
-    expected_tile = merge_all([raster1.get_tile(*tile), raster2.get_tile(*tile)], roi=eroi)
+    expected_tile = merge_all([raster1.get_tile(*tile), raster2.get_tile(*tile)],
+                              roi=eroi,
+                              dest_resolution=mercator_zoom_to_resolution[tile[2]])
     merged = fc.get_tile(*tile, sort_by='created')
     if merged is not None:
         assert merged == expected_tile


### PR DESCRIPTION
1. fixed resolution on `fc.get_tile` whan calling to `merge_all`
2. went back to a single thread pool for fetching tiles