### PR TITLE
Multivalue rasterization

### DIFF
--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -182,15 +182,12 @@ class BaseCollection(Sequence, NotebookPlottingMixin):
                   if not feature.is_empty]
 
         if bounds is None:
-            bounds = self.convex_hull.get_shape(crs)
+            bounds = self.envelope
 
         if bounds.area == 0.0:
             raise ValueError("Specify non-empty ROI")
 
-        elif isinstance(bounds, GeoVector):
-            bounds = bounds.get_shape(crs)
-
-        return rasterize(shapes, crs, bounds, dest_resolution, fill_value=fill_value)
+        return rasterize(shapes, crs, bounds.get_shape(crs), dest_resolution, fill_value=fill_value)
 
     def plot(self, mp=None, max_plot_rows=200, **plot_kwargs):
         if len(self) > max_plot_rows:

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -622,7 +622,7 @@ class GeoRaster2(WindowMethodsMixin):
             and self.shape == other.shape \
             and self.image.dtype == other.image.dtype \
             and np.array_equal(self.image.mask, other.image.mask) \
-            and np.array_equal(self.image, other.image)
+            and np.array_equal(np.ma.filled(self.image, 0), np.ma.filled(other.image, 0))
 
     def __getitem__(self, key):
         """

--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -350,7 +350,7 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
             new_shape = transform(self._shape, self._crs, new_crs)
             return self.__class__(new_shape, new_crs)
 
-    def rasterize(self, dest_resolution, *, fill_value=None, bounds=None, **kwargs):
+    def rasterize(self, dest_resolution, *, fill_value=None, bounds=None, dtype=None, **kwargs):
         # Import here to avoid circular imports
         from telluric import rasterization  # noqa
         crs = self.crs
@@ -363,7 +363,7 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
         if kwargs.pop("nodata_value", None):
             warnings.warn(rasterization.NODATA_DEPRECATION_WARNING, DeprecationWarning)
 
-        return rasterization.rasterize(shapes, crs, bounds, dest_resolution, fill_value=fill_value)
+        return rasterization.rasterize(shapes, crs, bounds, dest_resolution, fill_value=fill_value, dtype=dtype)
 
     def equals_exact(self, other, tolerance):
         """ invariant to crs. """

--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -5,7 +5,7 @@ import numpy as np
 import shapely.geometry
 from shapely.geometry import (
     shape as to_shape,
-    Point, MultiPoint, Polygon, MultiPolygon, LineString, MultiLineString,
+    Point, MultiPoint, Polygon, LineString, MultiLineString,
     CAP_STYLE,
     mapping)
 
@@ -391,7 +391,12 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
 
     def __eq__(self, other):
         """ invariant to crs and topology."""
-        return self.equals(other)
+        # Explicitly include method here instead of in GEOM_BINARY_PREDICATES,
+        # otherwise the delegation won't happen
+        return (
+            self.crs == other.crs
+            and self._shape.__eq__(other.get_shape(self.crs))
+        )
 
     def __str__(self):
         return '{cls}(shape={shape}, crs={crs})'.format(

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -242,13 +242,13 @@ def test_collection_slicing(fc):
 @mock.patch('telluric.collections.rasterize')
 def test_rasterize_without_bounds(mock_rasterize):
     fc = fc_generator(num_features=1)
-    fc.rasterize(dest_resolution=0.1, crs=DEFAULT_CRS, fill_value=29, nodata_value=-19)
+    fc.rasterize(dest_resolution=0.1, crs=DEFAULT_CRS, fill_value=29)
     f = next(iter(fc))
     expected_shape = [f.geometry.get_shape(f.geometry.crs)]
     expected_bounds = f.geometry.get_shape(f.geometry.crs)
     mock_rasterize.assert_called_with(expected_shape, DEFAULT_CRS,
                                       expected_bounds, 0.1,
-                                      29, -19)
+                                      fill_value=29)
 
 
 @mock.patch('telluric.collections.rasterize')
@@ -261,7 +261,7 @@ def test_rasterize_with_geovector_bounds(mock_rasterize):
     expected_shape = [f.geometry.get_shape(f.geometry.crs)]
     mock_rasterize.assert_called_with(expected_shape, DEFAULT_CRS,
                                       expected_bounds, 0.00001,
-                                      None, None)
+                                      fill_value=None)
 
 
 @mock.patch('telluric.collections.rasterize')
@@ -274,7 +274,7 @@ def test_rasterize_with_polygon_bounds(mock_rasterize):
     expected_shape = [f.geometry.get_shape(f.geometry.crs)]
     mock_rasterize.assert_called_with(expected_shape, DEFAULT_CRS,
                                       expected_bounds, 0.00001,
-                                      None, None)
+                                      fill_value=None)
 
 
 def test_file_collection_open():

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -245,7 +245,7 @@ def test_rasterize_without_bounds(mock_rasterize):
     fc.rasterize(dest_resolution=0.1, crs=DEFAULT_CRS, fill_value=29)
     f = next(iter(fc))
     expected_shape = [f.geometry.get_shape(f.geometry.crs)]
-    expected_bounds = f.geometry.get_shape(f.geometry.crs)
+    expected_bounds = fc.envelope.get_shape(fc.crs)
     mock_rasterize.assert_called_with(expected_shape, DEFAULT_CRS,
                                       expected_bounds, 0.1,
                                       fill_value=29)
@@ -256,19 +256,6 @@ def test_rasterize_with_geovector_bounds(mock_rasterize):
     fc = fc_generator(num_features=1)
     expected_bounds = Polygon.from_bounds(0, 0, 1, 1)
     bounds = GeoVector(expected_bounds, crs=DEFAULT_CRS)
-    fc.rasterize(0.00001, crs=DEFAULT_CRS, bounds=bounds)
-    f = next(iter(fc))
-    expected_shape = [f.geometry.get_shape(f.geometry.crs)]
-    mock_rasterize.assert_called_with(expected_shape, DEFAULT_CRS,
-                                      expected_bounds, 0.00001,
-                                      fill_value=None)
-
-
-@mock.patch('telluric.collections.rasterize')
-def test_rasterize_with_polygon_bounds(mock_rasterize):
-    fc = fc_generator(num_features=1)
-    expected_bounds = Polygon.from_bounds(0, 0, 1, 1)
-    bounds = expected_bounds
     fc.rasterize(0.00001, crs=DEFAULT_CRS, bounds=bounds)
     f = next(iter(fc))
     expected_shape = [f.geometry.get_shape(f.geometry.crs)]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -248,7 +248,7 @@ def test_rasterize_without_bounds(mock_rasterize):
     expected_bounds = fc.envelope.get_shape(fc.crs)
     mock_rasterize.assert_called_with(expected_shape, DEFAULT_CRS,
                                       expected_bounds, 0.1,
-                                      fill_value=29)
+                                      fill_value=29, dtype=None)
 
 
 @mock.patch('telluric.collections.rasterize')
@@ -261,7 +261,7 @@ def test_rasterize_with_geovector_bounds(mock_rasterize):
     expected_shape = [f.geometry.get_shape(f.geometry.crs)]
     mock_rasterize.assert_called_with(expected_shape, DEFAULT_CRS,
                                       expected_bounds, 0.00001,
-                                      fill_value=None)
+                                      fill_value=None, dtype=None)
 
 
 def test_file_collection_open():

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -17,6 +17,7 @@ from telluric.vectors import GeoVector
 some_array = np.array([[0, 1, 2], [3, 4, 5]], dtype=np.uint8)
 some_mask = np.array([[False, False, False], [False, False, True]], dtype=np.bool)
 some_image_2d = np.ma.array(some_array, mask=some_mask)
+some_image_2d_alt = np.ma.array(np.array([[0, 1, 2], [3, 4, 99]], dtype=np.uint8), mask=some_mask)
 some_image_3d = np.ma.array(some_array[np.newaxis, :, :], mask=some_mask[np.newaxis, :, :])
 some_image_3d_multiband = np.ma.array(
     np.array([some_array, some_array, some_array]), mask=np.array([some_mask, some_mask, some_mask]))
@@ -24,6 +25,7 @@ raster_origin = Point(2, 3)
 some_affine = Affine.translation(raster_origin.x, raster_origin.y)
 some_crs = {'init': 'epsg:32620'}
 some_raster = GeoRaster2(some_image_2d, affine=some_affine, crs=some_crs, band_names=['r'])
+some_raster_alt = GeoRaster2(some_image_2d_alt, affine=some_affine, crs=some_crs, band_names=['r'])
 some_raster_multiband = GeoRaster2(
     some_image_3d_multiband, band_names=['r', 'g', 'b'], affine=some_affine, crs=some_crs)
 default_factors = [2, 4, 8]
@@ -66,6 +68,10 @@ def test_eq():
     assert some_raster != some_raster.copy_with(image=some_raster.image + 1)
     assert some_raster != some_raster.copy_with(affine=Affine.translation(42, 42))
     assert some_raster != some_raster.copy_with(crs={'init': 'epsg:32621'})
+
+
+def test_eq_ignores_masked_values():
+    assert some_raster == some_raster_alt
 
 
 def test_read_write():

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -477,12 +477,12 @@ def test_polygonize_point():
 @mock.patch('telluric.rasterization.rasterize')
 def test_rasterize_without_bounds(mock_rasterize):
     gv = GeoVector(Polygon.from_bounds(0, 0, 1, 1))
-    gv.rasterize(dest_resolution=0.1, fill_value=29, nodata_value=-19)
+    gv.rasterize(dest_resolution=0.1, fill_value=29)
     expected_shape = [gv.get_shape(gv.crs)]
     expected_bounds = gv.envelope.get_shape(gv.crs)
     mock_rasterize.assert_called_with(expected_shape, gv.crs,
                                       expected_bounds, 0.1,
-                                      29, -19)
+                                      fill_value=29)
 
 
 @mock.patch('telluric.rasterization.rasterize')
@@ -494,7 +494,7 @@ def test_rasterize_with_geovector_bounds(mock_rasterize):
     expected_shape = [gv.get_shape(gv.crs)]
     mock_rasterize.assert_called_with(expected_shape, gv.crs,
                                       expected_bounds, 0.00001,
-                                      None, None)
+                                      fill_value=None)
 
 
 @mock.patch('telluric.rasterization.rasterize')
@@ -506,4 +506,4 @@ def test_rasterize_with_polygon_bounds(mock_rasterize):
     expected_shape = [gv.get_shape(gv.crs)]
     mock_rasterize.assert_called_with(expected_shape, gv.crs,
                                       expected_bounds, 0.00001,
-                                      None, None)
+                                      fill_value=None)

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -482,7 +482,7 @@ def test_rasterize_without_bounds(mock_rasterize):
     expected_bounds = gv.envelope.get_shape(gv.crs)
     mock_rasterize.assert_called_with(expected_shape, gv.crs,
                                       expected_bounds, 0.1,
-                                      fill_value=29)
+                                      fill_value=29, dtype=None)
 
 
 @mock.patch('telluric.rasterization.rasterize')
@@ -494,7 +494,7 @@ def test_rasterize_with_geovector_bounds(mock_rasterize):
     expected_shape = [gv.get_shape(gv.crs)]
     mock_rasterize.assert_called_with(expected_shape, gv.crs,
                                       expected_bounds, 0.00001,
-                                      fill_value=None)
+                                      fill_value=None, dtype=None)
 
 
 @mock.patch('telluric.rasterization.rasterize')
@@ -506,4 +506,4 @@ def test_rasterize_with_polygon_bounds(mock_rasterize):
     expected_shape = [gv.get_shape(gv.crs)]
     mock_rasterize.assert_called_with(expected_shape, gv.crs,
                                       expected_bounds, 0.00001,
-                                      fill_value=None)
+                                      fill_value=None, dtype=None)

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -457,7 +457,8 @@ def test_polygonize_line_square_cap_style():
 
     result = line.polygonize(1, cap_style_line=CAP_STYLE.square)
 
-    assert result == expected_result
+    # Don't use result == expected_result as topology might be different
+    assert result.equals(expected_result)
 
 
 def test_polygonize_point():

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -182,7 +182,24 @@ def test_rasterization_function():
         ]
     )
 
-    result = fc.rasterize(1.0, fill_value=func, crs=WGS84_CRS)
+    result = fc.rasterize(1.0, fill_value=func, crs=WGS84_CRS, dtype=np.float32)
 
     assert_array_equal(result.image.mask, expected_image.mask)
     assert_array_equal(result.image.data, expected_image.data)
+
+
+def test_rasterization_function_raises_error_if_no_dtype_is_given():
+    sq1 = GeoFeature(
+        GeoVector.from_bounds(xmin=0, ymin=2, xmax=1, ymax=3, crs=WGS84_CRS),
+        {'value': 1.0}
+    )
+    sq2 = GeoFeature(
+        GeoVector.from_bounds(xmin=1, ymin=0, xmax=3, ymax=2, crs=WGS84_CRS),
+        {'value': 2.0}
+    )
+    fc = FeatureCollection([sq1, sq2])
+
+    with pytest.raises(ValueError) as excinfo:
+        fc.rasterize(1.0, fill_value=lambda x: 1, crs=WGS84_CRS)
+
+    assert "dtype must be specified for multivalue rasterization" in excinfo.exconly()

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -70,7 +70,7 @@ def test_rasterization_of_line_simple():
 
     expected_result = GeoRaster2(expected_image, expected_affine, expected_crs)
 
-    result = fc.rasterize(resolution, pixels_width, crs=DEFAULT_CRS, bounds=roi)
+    result = fc.rasterize(resolution, polygonize_width=pixels_width, crs=DEFAULT_CRS, bounds=roi)
 
     assert result == expected_result
 
@@ -94,7 +94,7 @@ def test_rasterization_of_line_has_correct_pixel_width(resolution):
 
     expected_result = GeoRaster2(expected_image, expected_affine, expected_crs)
 
-    result = fc.rasterize(resolution, pixels_width, crs=DEFAULT_CRS, bounds=roi)
+    result = fc.rasterize(resolution, polygonize_width=pixels_width, crs=DEFAULT_CRS, bounds=roi)
 
     assert result == expected_result
 
@@ -113,7 +113,7 @@ def test_rasterization_point_single_pixel():
 
     roi = GeoVector.from_bounds(xmin=0, ymin=0, xmax=5, ymax=5, crs=WEB_MERCATOR_CRS)
 
-    result = fc.rasterize(1, 1, bounds=roi).image
+    result = fc.rasterize(1, polygonize_width=1, bounds=roi).image
 
     assert_array_equal(result.data, expected_image.data)
     assert_array_equal(result.mask, expected_image.mask)

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -134,8 +134,6 @@ def test_rasterization_function_user_dtype(fill_value, dtype):
     line = GeoVector.from_bounds(xmin=2, ymin=0, xmax=3, ymax=3, crs=DEFAULT_CRS)
     roi = GeoVector.from_bounds(xmin=0, ymin=0, xmax=5, ymax=5, crs=DEFAULT_CRS)
 
-    fc = FeatureCollection.from_geovectors([line])
-
     expected_data = np.zeros((5, 5), dtype=dtype)
     expected_data[2:, 2] = fill_value
     expected_mask = np.ones((5, 5), dtype=bool)
@@ -151,7 +149,7 @@ def test_rasterization_function_user_dtype(fill_value, dtype):
 
     expected_result = GeoRaster2(expected_image, expected_affine, expected_crs)
 
-    result = rasterize([feat.get_shape(DEFAULT_CRS) for feat in fc], DEFAULT_CRS, roi.get_shape(DEFAULT_CRS),
+    result = rasterize([line.get_shape(DEFAULT_CRS)], DEFAULT_CRS, roi.get_shape(DEFAULT_CRS),
                        resolution, fill_value=fill_value, dtype=dtype)
 
     assert result == expected_result


### PR DESCRIPTION
For the moment, I only prepared the ground: in particular, I fixed #28, and issues when comparing `GeoRaster2` and `GeoVector` objects.

My next steps will be putting the logic of multivalue rasterization in `BaseCollection.rasterize`, to keep `telluric.rasterization.rasterize` as a wrapper of `rasterio.features.rasterize`.