### PR TITLE
Improve GeoRaster dtype conversion

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -745,7 +745,9 @@ class GeoRaster2(WindowMethodsMixin, ProductsMixin, _Raster):
         :param in_range: str or 2-tuple, default 'dtype':
             'image': use image min/max as the intensity range,
             'dtype': use min/max of the image's dtype as the intensity range,
-            2-tuple: use explicit min/max intensities
+            2-tuple: use explicit min/max intensities, it is possible to use
+                     'min' or 'max' as tuple values - in this case they will be
+                     replaced by min or max intensity of image respectively
         :param out_range: str or 2-tuple, default 'dtype':
             'dtype': use min/max of the image's dtype as the intensity range,
             2-tuple: use explicit min/max intensities
@@ -798,6 +800,10 @@ class GeoRaster2(WindowMethodsMixin, ProductsMixin, _Raster):
                 imax = max(self.max())
             else:
                 imin, imax = in_range
+                if imin == 'min':
+                    imin = min(self.min())
+                if imax == 'max':
+                    imax = max(self.max())
 
             if imin == imax:
                 conversion_gain = 0

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -588,6 +588,15 @@ def test_astype_uint8_to_float32_conversion_with_image_in_range():
 
 
 def test_astype_uint8_to_float32_conversion_with_custom_in_range():
+    raster_float32 = some_raster.astype(np.float32, in_range=('min', 'max'), out_range=(0, 1))
+    expected_raster_float32 = GeoRaster2(image=np.ma.array(
+        np.array([
+            [0.0, 0.25, 0.5],
+            [0.75, 1.0, 1.0]
+        ], dtype=np.float32), mask=some_raster.image.mask),
+        affine=some_float32_raster.affine, crs=some_float32_raster.crs, nodata=None)
+    assert raster_float32 == expected_raster_float32
+
     raster_float32 = some_raster.astype(np.float32, in_range=(2, 4), out_range=(0, 1))
     expected_raster_float32 = GeoRaster2(image=np.ma.array(
         np.array([


### PR DESCRIPTION
This PR allows convert GeoRaster to and from floats. Values of `in_range` and `out_range` are used for all bands (per band ranges are not supported). Please review.