### PR TITLE
Adding a general purpose context manager

### DIFF
--- a/telluric/context.py
+++ b/telluric/context.py
@@ -28,11 +28,11 @@ class TelluricContext(object):
         with TelluricContext(sensor_bands_info=bands_mapping):
             return raster.apply('NDVI')
 
-    The arguments are saved `local_contex` and to read them just use `local_context.get("argument_name"), for example:
+    The arguments are saved in the `context` module under `local_contex` and to read them just use `local_context.get("argument_name"), for example:
         
         from telluric.context import local_context, TelluricContext
         
-        with TelluriContex('a'=11):
+        with TelluricContex('a'=11):
             local_context.get('a')  # => 11
             local_context.get('b')  # => None
             local_context.get('c', 44)  # => 44
@@ -40,8 +40,8 @@ class TelluricContext(object):
     TelluricContext can be nested and in that case the inner context overides the outer, for example:
         from telluric.context import local_context, TelluricContext
         
-        with TelluriContex('a'=11):
-            with TelluriContex('a'=33, 'b'='some_str'):
+        with TelluricContex('a'=11):
+            with TelluricContex('a'=33, 'b'='some_str'):
                 local_context.get('a')  # => 33
                 local_context.get('b')  # => some_str
             local_context.get('a')  # => 11

--- a/telluric/context.py
+++ b/telluric/context.py
@@ -96,7 +96,7 @@ class TelluricContext(object):
         """
         options = TelluricContext.default_options()
         options.update(**kwargs)
-        return TelluricContext(**options)
+        return cls(**options)
 
     def __enter__(self):
         log.debug("Entering env context: %r", self)

--- a/telluric/context.py
+++ b/telluric/context.py
@@ -29,10 +29,11 @@ class TelluricContext(object):
         with TelluricContext(sensor_bands_info=bands_mapping):
             return raster.apply('NDVI')
 
-    The arguments are saved in the `context` module under `local_contex` and to read them just use `local_context.get("argument_name"), for example:
-        
+    The arguments are saved in the `context` module under `local_contex` and to read them just use
+    `local_context.get("argument_name"), for example:
+
         from telluric.context import local_context, TelluricContext
-        
+
         with TelluricContex('a'=11):
             local_context.get('a')  # => 11
             local_context.get('b')  # => None
@@ -40,7 +41,7 @@ class TelluricContext(object):
 
     TelluricContext can be nested and in that case the inner context overides the outer, for example:
         from telluric.context import local_context, TelluricContext
-        
+
         with TelluricContex('a'=11):
             with TelluricContex('a'=33, 'b'='some_str'):
                 local_context.get('a')  # => 33
@@ -76,7 +77,7 @@ class TelluricContext(object):
         TelluricContext
         """
         self.options = options.copy()
-        self.context_options = {}  #type: dict
+        self.context_options = {}  # type: dict
 
     @classmethod
     def from_defaults(cls, **kwargs):
@@ -153,4 +154,3 @@ def del_context():
     if not local_context._options:
         raise TelluricContextError("TelluricContext context not exists")
     local_context._options = None
-

--- a/telluric/context.py
+++ b/telluric/context.py
@@ -5,7 +5,8 @@ import threading
 
 class ThreadContext(threading.local):
     def __init__(self):
-        self._options = None  # Initialises in each thread
+        # Initializes in each thread
+        self._options = None  # type: dict
 
     def get(self, key, default=None):
         return self._options.get(key, default)
@@ -75,17 +76,15 @@ class TelluricContext(object):
         TelluricContext
         """
         self.options = options.copy()
-        self.context_options = {}
+        self.context_options = {}  #type: dict
 
     @classmethod
-    def from_defaults(cls, *args, **kwargs):
+    def from_defaults(cls, **kwargs):
         """Create a context with default config options
         Parameters
         ----------
-        args : optional
-            Positional arguments for Env()
         kwargs : optional
-            Keyword arguments for Env()
+            Keyword arguments for TelluricContext()
         Returns
         -------
         TelluricContext
@@ -95,7 +94,7 @@ class TelluricContext(object):
         """
         options = TelluricContext.default_options()
         options.update(**kwargs)
-        return TelluricContext(*args, **options)
+        return TelluricContext(**options)
 
     def __enter__(self):
         log.debug("Entering env context: %r", self)

--- a/telluric/context.py
+++ b/telluric/context.py
@@ -100,7 +100,7 @@ class TelluricContext(object):
 
     def __enter__(self):
         log.debug("Entering env context: %r", self)
-        # No parent Rasterio environment exists.
+        # No parent TelluricContext exists.
         if local_context._options is None:
             log.debug("Starting outermost env")
             self._has_parent_env = False

--- a/telluric/context.py
+++ b/telluric/context.py
@@ -1,4 +1,7 @@
-"""Telluric thread local context manager."""
+"""Telluric thread local context manager.
+
+Inspired by rasterio, (c) MapBox, MIT License
+"""
 import logging
 import threading
 from typing import Optional

--- a/telluric/context.py
+++ b/telluric/context.py
@@ -1,0 +1,157 @@
+"""Telluric thread local context manager."""
+import logging
+import threading
+
+
+class ThreadContext(threading.local):
+    def __init__(self):
+        self._options = None  # Initialises in each thread
+
+    def get(self, key, default=None):
+        return self._options.get(key, default)
+
+
+local_context = ThreadContext()
+
+log = logging.getLogger(__name__)
+
+
+class TelluricContextError(Exception):
+    pass
+
+
+class TelluricContext(object):
+    """TelluricContext is a thread.local context manager for telluric parameters,
+    that can be used in telluric functionalities.
+
+    Example when applying a product on a raster for setting sensor_bands_info:
+        with TelluricContext(sensor_bands_info=bands_mapping):
+            return raster.apply('NDVI')
+
+    The arguments are saved `local_contex` and to read them just use `local_context.get("argument_name"), for example:
+        
+        from telluric.context import local_context, TelluricContext
+        
+        with TelluriContex('a'=11):
+            local_context.get('a')  # => 11
+            local_context.get('b')  # => None
+            local_context.get('c', 44)  # => 44
+
+    TelluricContext can be nested and in that case the inner context overides the outer, for example:
+        from telluric.context import local_context, TelluricContext
+        
+        with TelluriContex('a'=11):
+            with TelluriContex('a'=33, 'b'='some_str'):
+                local_context.get('a')  # => 33
+                local_context.get('b')  # => some_str
+            local_context.get('a')  # => 11
+            local_context.get('b')  # => None
+    """
+
+    @classmethod
+    def default_options(cls):
+        """Default configuration options
+        Parameters
+        ----------
+        None
+        Returns
+        -------
+        dict
+        """
+        return {
+        }
+
+    def __init__(
+            self, **options):
+        """Create a new telluricContext settings.
+        Parameters
+        ----------
+        **options : optional
+            A mapping of key:value options, e.g.,
+            `CPL_DEBUG=True, CHECK_WITH_INVERT_PROJ=False`.
+
+        Returns
+        -------
+        TelluricContext
+        """
+        self.options = options.copy()
+        self.context_options = {}
+
+    @classmethod
+    def from_defaults(cls, *args, **kwargs):
+        """Create a context with default config options
+        Parameters
+        ----------
+        args : optional
+            Positional arguments for Env()
+        kwargs : optional
+            Keyword arguments for Env()
+        Returns
+        -------
+        TelluricContext
+        Notes
+        -----
+        The items in kwargs will be overlaid on the default values.
+        """
+        options = TelluricContext.default_options()
+        options.update(**kwargs)
+        return TelluricContext(*args, **options)
+
+    def __enter__(self):
+        log.debug("Entering env context: %r", self)
+        # No parent Rasterio environment exists.
+        if local_context._options is None:
+            log.debug("Starting outermost env")
+            self._has_parent_env = False
+
+            reset_context(**self.options)
+            self.context_options = {}
+        else:
+            self._has_parent_env = True
+            self.context_options = get_context()
+            set_context(**self.options)
+
+        log.debug("Entered env context: %r", self)
+        return self
+
+    def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
+        log.debug("Exiting env context: %r", self)
+        del_context()
+        if self._has_parent_env:
+            reset_context(**self.context_options)
+        else:
+            log.debug("Exiting outermost env")
+        log.debug("Exited env context: %r", self)
+
+
+def reset_context(**options):
+    """Reset context to default."""
+    local_context._options = {}
+    local_context._options.update(options)
+    log.debug("New TelluricContext context %r created", local_context._options)
+
+
+def get_context():
+    """Get a mapping of current options."""
+    if not local_context._options:
+        raise TelluricContextError("TelluricContext context not exists")
+    else:
+        log.debug("Got a copy of context %r options", local_context._options)
+        return local_context._options.copy()
+
+
+def set_context(**options):
+    """Set options in the existing context."""
+    if not local_context._options:
+        raise TelluricContextError("TelluricContext context not exists")
+    else:
+        local_context._options.update(options)
+        log.debug("Updated existing %r with options %r", local_context._options, options)
+
+
+def del_context():
+    """Delete options in the existing context."""
+    if not local_context._options:
+        raise TelluricContextError("TelluricContext context not exists")
+    local_context._options = None
+

--- a/telluric/context.py
+++ b/telluric/context.py
@@ -1,12 +1,13 @@
 """Telluric thread local context manager."""
 import logging
 import threading
+from typing import Optional
 
 
 class ThreadContext(threading.local):
     def __init__(self):
         # Initializes in each thread
-        self._options = None  # type: dict
+        self._options = None  # type: Optional[dict]
 
     def get(self, key, default=None):
         return self._options.get(key, default)

--- a/telluric/products_mixin.py
+++ b/telluric/products_mixin.py
@@ -14,7 +14,7 @@ class ProductsMixin:
             Name of requested product
         sensor_bands_info: dict
             Bands wave length definition including max and min wave per bands name, if it is not set as an argument
-            it should be set in TelluricContext 
+            it should be set in TelluricContext
         metadata: bool
             Optional, when True it returns a namedtuple withe resulting raster and additional product information
         kwargs: dict
@@ -29,7 +29,7 @@ class ProductsMixin:
             sensor_bands_info = local_context.get('sensor_bands_info')
         if sensor_bands_info is None:
             raise ProductError("sensor_bands_info must be supplied")
-    
+
         generator = ProductsFactory.get_object(product_name, **kwargs)
         product = generator.apply(sensor_bands_info, self, metadata=metadata)
         return product
@@ -61,7 +61,7 @@ class ProductsMixin:
         ----------
         sensor_bands_info: dict
             Bands wave length definition including max and min wave per bands name, if it is not set as an argument
-            it should be set in TelluricContext 
+            it should be set in TelluricContext
 
         Rerturns
         --------
@@ -71,5 +71,5 @@ class ProductsMixin:
             sensor_bands_info = local_context.get('sensor_bands_info')
         if sensor_bands_info is None:
             raise ProductError("sensor_bands_info must be supplied")
-        
+
         return ProductsFactory.get_matchings(self.band_names, sensor_bands_info)

--- a/telluric/products_mixin.py
+++ b/telluric/products_mixin.py
@@ -1,27 +1,35 @@
-from telluric.products import ProductsFactory
+"""Mixin to make products functionality first members in GeoRaster2."""
+from telluric.products import ProductsFactory, ProductError
 from telluric.product_view import ProductViewsFactory
+from telluric.context import local_context
 
 
 class ProductsMixin:
-    def apply(self, sensor_bands_info, product_name, metadata=False, **kwargs):
+    def apply(self, product_name, sensor_bands_info=None, metadata=False, **kwargs):
         """Apply a product on a raster, from a pre defined list of products, such as NVDI.
 
         Parameters
         ----------
-        sensor_bands_info: dict
-            Bands wave lenght definition including max and min wave per bands name
         product_name: str
             Name of requested product
+        sensor_bands_info: dict
+            Bands wave length definition including max and min wave per bands name, if it is not set as an argument
+            it should be set in TelluricContext 
         metadata: bool
             Optional, when True it returns a namedtuple withe resulting raster and additional product information
         kwargs: dict
-            Additional arguments, required to generate the poduct like the band name for SingleBand product
+            Additional arguments, required to generate the product like the band name for SingleBand product
 
-        Rerturns
+        Returns
         --------
         GeoRaster2
         Product()
         """
+        if sensor_bands_info is None:
+            sensor_bands_info = local_context.get('sensor_bands_info')
+        if sensor_bands_info is None:
+            raise ProductError("sensor_bands_info must be supplied")
+    
         generator = ProductsFactory.get_object(product_name, **kwargs)
         product = generator.apply(sensor_bands_info, self, metadata=metadata)
         return product
@@ -46,16 +54,22 @@ class ProductsMixin:
         view = generator.apply(self, **kwargs)
         return view
 
-    def get_products(self, sensor_bands_info):
+    def get_products(self, sensor_bands_info=None):
         """Return a list of product names applicable to the raster.
 
         Parameters
         ----------
         sensor_bands_info: dict
-            Bands wave lenght definition including max and min wave per bands name
+            Bands wave length definition including max and min wave per bands name, if it is not set as an argument
+            it should be set in TelluricContext 
 
         Rerturns
         --------
         list(str)
         """
+        if sensor_bands_info is None:
+            sensor_bands_info = local_context.get('sensor_bands_info')
+        if sensor_bands_info is None:
+            raise ProductError("sensor_bands_info must be supplied")
+        
         return ProductsFactory.get_matchings(self.band_names, sensor_bands_info)

--- a/tests/test_product_mixin.py
+++ b/tests/test_product_mixin.py
@@ -1,5 +1,6 @@
 import pytest
 from telluric import GeoRaster2
+from telluric.context import TelluricContext
 
 from common_for_tests import (
     multi_raster_8b, sensor_bands_info,
@@ -26,9 +27,9 @@ def test_multispectral_apply_product():
     raster = multi_raster_8b()
     for product_name in raster.get_products(sensor_bands_info()):
         if product_name == 'SingleBand':
-            product = raster.apply(sensor_bands_info(), product_name, band=raster.band_names[0])
+            product = raster.apply(product_name, sensor_bands_info(), band=raster.band_names[0])
         else:
-            product = raster.apply(sensor_bands_info(), product_name)
+            product = raster.apply(product_name, sensor_bands_info())
 
         assert isinstance(product, GeoRaster2)
 
@@ -37,9 +38,9 @@ def test_hyper_apply_product():
     raster = hyper_raster()
     for product_name in raster.get_products(sensor_bands_info()):
         if product_name == 'SingleBand':
-            product = raster.apply(sensor_bands_info(), product_name, band=raster.band_names[0])
+            product = raster.apply(product_name, sensor_bands_info(), band=raster.band_names[0])
         else:
-            product = raster.apply(sensor_bands_info(), product_name)
+            product = raster.apply(product_name, sensor_bands_info())
 
         assert isinstance(product, GeoRaster2)
 
@@ -50,7 +51,7 @@ def test_hyper_apply_product():
                                     hyper_raster_with_no_data(),
                                     multi_raster_with_no_data()])
 def test_it_visualized_to_colormap(raster):
-    result = raster.apply(sensor_bands_info(), 'ndvi').visualize('cm-jet', vmax=1, vmin=-1)
+    result = raster.apply('ndvi', sensor_bands_info()).visualize('cm-jet', vmax=1, vmin=-1)
     assert isinstance(result, GeoRaster2)
     assert result.band_names == ['red', 'green', 'blue']
 
@@ -61,7 +62,7 @@ def test_it_visualized_to_colormap(raster):
                                     hyper_raster_with_no_data(),
                                     multi_raster_with_no_data()])
 def test_it_visualized_to_default(raster):
-    product = raster.apply(sensor_bands_info(), 'ndvi', metadata=True)
+    product = raster.apply('ndvi', sensor_bands_info(), metadata=True)
     result = product.raster.visualize(product.default_view, vmax=product.max, vmin=product.min)
     assert isinstance(result, GeoRaster2)
     assert result.band_names == ['red', 'green', 'blue']
@@ -73,7 +74,7 @@ def test_it_visualized_to_default(raster):
                                     hyper_raster_with_no_data(),
                                     multi_raster_with_no_data()])
 def test_it_visualized_to_rgb(raster):
-    result = raster.apply(sensor_bands_info(), 'TrueColor').visualize('TrueColor')
+    result = raster.apply('TrueColor', sensor_bands_info()).visualize('TrueColor')
     assert isinstance(result, GeoRaster2)
     assert result.band_names == ['red', 'green', 'blue']
 
@@ -85,3 +86,15 @@ def test_it_visualized_multispectral_to_rgb_with_no_product(raster):
     result = raster.visualize('TrueColor')
     assert isinstance(result, GeoRaster2)
     assert result.band_names == ['red', 'green', 'blue']
+
+
+@pytest.mark.parametrize("raster", [multi_raster_16b(),
+                                    multi_raster_8b(),
+                                    hyper_raster(),
+                                    hyper_raster_with_no_data(),
+                                    multi_raster_with_no_data()])
+def test_use_context_manager_for_bands_info(raster):
+    with TelluricContext(sensor_bands_info=sensor_bands_info()):
+        result = raster.apply('ndvi').visualize('cm-jet', vmax=1, vmin=-1)
+        assert isinstance(result, GeoRaster2)
+        assert result.band_names == ['red', 'green', 'blue']

--- a/tests/test_telluric_context.py
+++ b/tests/test_telluric_context.py
@@ -1,0 +1,58 @@
+from telluric.context import local_context, TelluricContext
+
+
+def test_context_in_one_level():
+    with TelluricContext(a=1, b=2, c='stam', d={'a': 'a', 'b': 'b'}):
+        assert local_context.get('a') == 1
+        assert local_context.get('b') == 2
+        assert local_context.get('c') == 'stam'
+        assert local_context.get('d') == {'a': 'a', 'b': 'b'}
+    assert local_context._options is None
+
+
+def test_context_in_two_level():
+    with TelluricContext(a=1, b=2, c='stam', d={'a': 'a', 'b': 'b'}):
+        with TelluricContext(a=4, b=5, x='something', y=13):
+            assert local_context.get('a') == 4
+            assert local_context.get('b') == 5
+            assert local_context.get('c') == 'stam'
+            assert local_context.get('d') == {'a': 'a', 'b': 'b'}
+            assert local_context.get('x') == 'something'
+            assert local_context.get('y') == 13
+        assert local_context.get('a') == 1
+        assert local_context.get('b') == 2
+        assert local_context.get('c') == 'stam'
+        assert local_context.get('d') == {'a': 'a', 'b': 'b'}
+    assert local_context._options is None
+
+
+def test_different_context_on_different_threads():
+    import threading
+
+    class MyThread (threading.Thread):
+        def start(self):
+            with TelluricContext(a=1, b=2, c='stam', d={'a': 'a', 'b': 'b'}):
+                assert local_context.get('a') == 1
+                assert local_context.get('b') == 2
+                assert local_context.get('c') == 'stam'
+                assert local_context.get('d') == {'a': 'a', 'b': 'b'}
+                assert local_context.get('x') is None
+                assert local_context.get('y') is None
+            assert local_context._options is None
+
+    class MyThread2 (threading.Thread):
+        def start(self):
+            with TelluricContext(a=4, b=5, x='something', y=13):
+                assert local_context.get('a') == 4
+                assert local_context.get('b') == 5
+                assert local_context.get('x') == 'something'
+                assert local_context.get('y') == 13
+                assert local_context.get('c') is None
+                assert local_context.get('d') is None
+            assert local_context._options is None
+
+    assert local_context._options is None
+    MyThread().start()
+    assert local_context._options is None
+    MyThread2().start()
+    assert local_context._options is None

--- a/tests/test_telluric_context.py
+++ b/tests/test_telluric_context.py
@@ -28,31 +28,35 @@ def test_context_in_two_level():
 
 def test_different_context_on_different_threads():
     import threading
+    from time import sleep
 
-    class MyThread (threading.Thread):
-        def start(self):
-            with TelluricContext(a=1, b=2, c='stam', d={'a': 'a', 'b': 'b'}):
-                assert local_context.get('a') == 1
-                assert local_context.get('b') == 2
-                assert local_context.get('c') == 'stam'
-                assert local_context.get('d') == {'a': 'a', 'b': 'b'}
-                assert local_context.get('x') is None
-                assert local_context.get('y') is None
-            assert local_context._options is None
+    def thread_test_1():
+        with TelluricContext(a=1, b=2, c='stam', d={'a': 'a', 'b': 'b'}):
+            sleep(0.1)
+            assert local_context.get('a') == 1
+            assert local_context.get('b') == 2
+            assert local_context.get('c') == 'stam'
+            assert local_context.get('d') == {'a': 'a', 'b': 'b'}
+            assert local_context.get('x') is None
+            assert local_context.get('y') is None
+        assert local_context._options is None
 
-    class MyThread2 (threading.Thread):
-        def start(self):
-            with TelluricContext(a=4, b=5, x='something', y=13):
-                assert local_context.get('a') == 4
-                assert local_context.get('b') == 5
-                assert local_context.get('x') == 'something'
-                assert local_context.get('y') == 13
-                assert local_context.get('c') is None
-                assert local_context.get('d') is None
-            assert local_context._options is None
+    def thread_test_2():
+        with TelluricContext(a=4, b=5, x='something', y=13):
+            assert local_context.get('a') == 4
+            assert local_context.get('b') == 5
+            assert local_context.get('x') == 'something'
+            assert local_context.get('y') == 13
+            assert local_context.get('c') is None
+            assert local_context.get('d') is None
+            sleep(0.1)
+        assert local_context._options is None
 
+    t1 = threading.Thread(target=thread_test_1)
+    t2 = threading.Thread(target=thread_test_2)
+    t1.start()
+    t2.start()
     assert local_context._options is None
-    MyThread().start()
-    assert local_context._options is None
-    MyThread2().start()
+    t1.join()
+    t2.join()
     assert local_context._options is None


### PR DESCRIPTION
TelluricContext is a thread.local context manager for telluric parameters, that can be used in telluric functionalities.

Example when applying a product on a raster for setting sensor_bands_info:
```
        with TelluricContext(sensor_bands_info=bands_mapping):
            return raster.apply('NDVI')
```

The arguments are saved `local_contex` and to read them just use `local_context.get("argument_name")`, for example:

```        
        from telluric.context import local_context, TelluricContext
        
        with TelluriContex('a'=11):
            local_context.get('a')  # => 11
            local_context.get('b')  # => None
            local_context.get('c', 44)  # => 44
```
TelluricContext can be nested and in that case the inner context overides the outer, for example:

```
        from telluric.context import local_context, TelluricContext
        
        with TelluriContex('a'=11):
            with TelluriContex('a'=33, 'b'='some_str'):
                local_context.get('a')  # => 33
                local_context.get('b')  # => some_str
            local_context.get('a')  # => 11
            local_context.get('b')  # => None
```