### PR TITLE
Fix CRS/dict comparison warnings

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -526,6 +526,7 @@ class GeoRaster2(WindowMethodsMixin, ProductsMixin, _Raster):
         with self._raster_opener(self._filename) as raster:  # type: rasterio.DatasetReader
             self._affine = copy(raster.transform)
             self._crs = copy(raster.crs)
+            assert self._crs.is_valid
             self._dtype = np.dtype(raster.dtypes[0])
 
             # if band_names not provided, try read them from raster tags.

--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -10,6 +10,8 @@ from shapely.geometry import (
     CAP_STYLE,
     mapping)
 
+from rasterio.crs import CRS
+
 from telluric.constants import DEFAULT_CRS, EQUAL_AREA_CRS, WGS84_CRS
 from telluric.plotting import NotebookPlottingMixin
 from telluric.util.projections import transform
@@ -250,12 +252,13 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
         ----------
         shape : shapely.geometry.BaseGeometry
             Geometry.
-        crs : ~rasterio.crs.CRS, dict (optional)
+        crs : ~rasterio.crs.CRS (optional)
             Coordinate Reference System, default to :py:data:`telluric.constants.DEFAULT_CRS`.
 
         """
         self._shape = shape  # type: shapely.geometry.base.BaseGeometry
-        self._crs = crs
+        self._crs = CRS(crs)
+        assert self._crs.is_valid
 
     @classmethod
     def from_geojson(cls, filename):

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -1,18 +1,21 @@
 import pytest
 import os
 from tempfile import TemporaryDirectory
-from copy import copy, deepcopy
+from copy import deepcopy
 
 import numpy as np
 from affine import Affine
 from rasterio.enums import Resampling
 from PIL import Image
 from shapely.geometry import Point, Polygon
-from common_for_tests import make_test_raster
+
+from rasterio.crs import CRS
 
 from telluric.constants import WGS84_CRS, WEB_MERCATOR_CRS
 from telluric.georaster import GeoRaster2, GeoRaster2Error, GeoRaster2Warning
 from telluric.vectors import GeoVector
+
+from common_for_tests import make_test_raster
 
 
 some_array = np.array([[0, 1, 2], [3, 4, 5]], dtype=np.uint8)
@@ -24,7 +27,7 @@ some_image_3d_multiband = np.ma.array(
     np.array([some_array, some_array, some_array]), mask=np.array([some_mask, some_mask, some_mask]))
 raster_origin = Point(2, 3)
 some_affine = Affine.translation(raster_origin.x, raster_origin.y)
-some_crs = {'init': 'epsg:32620'}
+some_crs = CRS({'init': 'epsg:32620'})
 some_raster = GeoRaster2(some_image_2d, affine=some_affine, crs=some_crs, band_names=['r'])
 some_raster_alt = GeoRaster2(some_image_2d_alt, affine=some_affine, crs=some_crs, band_names=['r'])
 some_raster_multiband = GeoRaster2(

--- a/tests/test_georaster_tiling.py
+++ b/tests/test_georaster_tiling.py
@@ -141,7 +141,7 @@ class GeoRaster2TestGetTile(TestCase):
 
     def test_geo_bounding_tile(self):
         gr = self.raster_for_test()
-        gv = gr.footprint().reproject({'init': 'epsg:4326'})
+        gv = gr.footprint().reproject(CRS({'init': 'epsg:4326'}))
         bounding_tile = mercantile.bounding_tile(*gv.get_shape(gv.crs).bounds)
         self.assertEqual(bounding_tile, (2319, 1578, 12))
 

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -8,6 +8,8 @@ from pytest import approx
 
 from shapely.geometry import Point, Polygon, mapping, LineString, CAP_STYLE
 
+from rasterio.crs import CRS
+
 from telluric.vectors import (
     GeoVector,
     GEOM_PROPERTIES, GEOM_UNARY_PREDICATES, GEOM_UNARY_OPERATIONS, GEOM_BINARY_PREDICATES, GEOM_BINARY_OPERATIONS,
@@ -25,7 +27,7 @@ def test_geovector_has_shape_and_default_crs():
 
 
 def test_geovector_has_given_crs():
-    crs = {'crs'}
+    crs = CRS({'init': 'epsg:4326'})
     gv = GeoVector(None, crs)
 
     assert gv.crs == crs
@@ -72,7 +74,7 @@ def test_geovector_to_from_geojson():
 
 def test_reproject_changes_crs():
     shape = Point(0.0, 40.0)
-    new_crs = {'init': 'epsg:32630'}
+    new_crs = CRS({'init': 'epsg:32630'})
 
     gv = GeoVector(shape)
 
@@ -164,8 +166,8 @@ def test_geo_interface():
 
 
 def test_almost_equals():
-    some_crs = {'init': 'epsg:32630'}
-    another_crs = {'init': 'epsg:32631'}
+    some_crs = CRS({'init': 'epsg:32630'})
+    another_crs = CRS({'init': 'epsg:32631'})
 
     pt = GeoVector(Point(0, 0), some_crs)
 

--- a/tests/test_product_view.py
+++ b/tests/test_product_view.py
@@ -5,6 +5,7 @@ import numpy as np
 import affine
 import telluric as tl
 from telluric.constants import WGS84_CRS
+
 from common_for_tests import make_test_raster, multi_raster_16b, multi_values_16b
 
 

--- a/tests/test_rasterization.py
+++ b/tests/test_rasterization.py
@@ -1,10 +1,11 @@
 import pytest
 
+import numpy as np
 from affine import Affine
 from numpy.testing import assert_array_equal
 from shapely.geometry import Polygon, LineString, Point
 
-import numpy as np
+from rasterio.crs import CRS
 
 from telluric.vectors import GeoVector
 from telluric.features import GeoFeature
@@ -35,7 +36,7 @@ def test_rasterization_raise_error_for_too_big_image():
 
 def test_rasterization_has_expected_affine_and_crs():
     shape = Polygon([(0, 0), (1, 0), (1, -1), (0, -1)])
-    crs = {'init': 'epsg:32631'}
+    crs = CRS({'init': 'epsg:32631'})
     fcol = FeatureCollection([GeoFeature(GeoVector(shape, crs), {})])
 
     expected_affine = ~Affine(1.0, 0.0, 0.0, 0.0, -1.0, 0.0)


### PR DESCRIPTION
This will make none of the tests fail when rasterio 1.0 is out. Notice that now things like `reproject` require a `CRS` and not a `dict` object.