### PR TITLE
Fix Issue #76 where rasterio.window breaks on positive e 

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1624,7 +1624,6 @@ class GeoRaster2(WindowMethodsMixin, ProductsMixin, _Raster):
         :param blocksize: tile size  (x & y) default 256, for full resolution pass None
         :return: GeoRaster2 of tile
         """
-        # import pdb; pdb.set_trace()
         coordinates = mercantile.xy_bounds(x_tile, y_tile, zoom)
         window = self._window(coordinates)
         return self.get_window(window, bands=bands,

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -834,13 +834,24 @@ class GeoRaster2(WindowMethodsMixin, ProductsMixin, _Raster):
 
         return self.pixel_crop(bounds, xsize, ysize, window=window)
 
+    def _window(self, bounds):
+        # self.window expects to receive the arguments west, south, east, north,
+        # so for positive e in affine we should swap top and bottom
+        if self.affine[4] > 0:
+            window = self.window(bounds[0], bounds[3], bounds[2], bounds[1], precision=6)
+        else:
+            window = self.window(*bounds, precision=6)
+
+        window = window.round_offsets().round_shape(op='ceil', pixel_precision=3)
+        return window
+
     def _vector_to_raster_bounds(self, vector, boundless=False):
         # bounds = tuple(round(bb) for bb in self.to_raster(vector).bounds)
         bounds = vector.get_shape(self.crs).bounds
         if any(map(math.isinf, bounds)):
             raise GeoRaster2Error('bounds %s cannot be transformed from %s to %s' % (
                 vector.get_shape(vector.crs).bounds, vector.crs, self.crs))
-        window = self.window(*bounds, precision=6).round_offsets().round_shape(op='ceil', pixel_precision=3)
+        window = self._window(bounds)
         (ymin, ymax), (xmin, xmax) = window.toranges()
         bounds = (xmin, ymin, xmax, ymax)
         if not boundless:
@@ -1568,8 +1579,9 @@ class GeoRaster2(WindowMethodsMixin, ProductsMixin, _Raster):
         :param blocksize: tile size  (x & y) default 256, for full resolution pass None
         :return: GeoRaster2 of tile
         """
+        # import pdb; pdb.set_trace()
         coordinates = mercantile.xy_bounds(x_tile, y_tile, zoom)
-        window = self.window(*coordinates).round_offsets().round_shape(op='ceil')
+        window = self._window(coordinates)
         return self.get_window(window, bands=bands,
                                xsize=blocksize, ysize=blocksize)
 

--- a/tests/test_georaster_tiling.py
+++ b/tests/test_georaster_tiling.py
@@ -449,13 +449,13 @@ class GeoRasterCropTest(TestCase):
         r1 = GeoRaster2(image=image1, affine=aff, crs=WEB_MERCATOR_CRS)
         r2 = GeoRaster2(image=image2, affine=aff2, crs=WEB_MERCATOR_CRS)
 
-        # r1 == r2  # should be true in my opinion
+        # r1 == r2  # doesn't work, see https://github.com/satellogic/telluric/issues/79
         roi = GeoVector(Polygon.from_bounds(0, 0, 3, -3), crs=WEB_MERCATOR_CRS)
 
         r1c = r1.crop(roi)
         r2c = r2.crop(roi)
 
-        # r1c == r2c  #should be true
+        # r1c == r2c  # doesn't work, see https://github.com/satellogic/telluric/issues/79
         # currently this is the only way to test the result is the same
         assert r2c.to_png() == r1c.to_png()
 

--- a/tests/test_georaster_tiling.py
+++ b/tests/test_georaster_tiling.py
@@ -435,6 +435,30 @@ class GeoRasterCropTest(TestCase):
         with self.assertRaises(GeoRaster2Error):
             raster.crop(vector)
 
+    def test_crop_of_rasters_with_opposite_affine_and_data_return_the_same(self):
+        array = np.arange(0, 20).reshape(1, 4, 5)
+        array2 = np.arange(19, -1, -1).reshape(1, 4, 5)
+        array2.sort()
+
+        image1 = np.ma.array(array, mask=False)
+        image2 = np.ma.array(array2, mask=False)
+
+        aff2 = Affine.translation(0, -8) * Affine.scale(2, 2)
+        aff = Affine.scale(2, -2)
+
+        r1 = GeoRaster2(image=image1, affine=aff, crs=WEB_MERCATOR_CRS)
+        r2 = GeoRaster2(image=image2, affine=aff2, crs=WEB_MERCATOR_CRS)
+
+        # r1 == r2  # should be true in my opinion
+        roi = GeoVector(Polygon.from_bounds(0, 0, 3, -3), crs=WEB_MERCATOR_CRS)
+
+        r1c = r1.crop(roi)
+        r2c = r2.crop(roi)
+
+        # r1c == r2c  #should be true
+        # currently this is the only way to test the result is the same
+        assert r2c.to_png() == r1c.to_png()
+
 
 class GeoRasterMaskedTest(TestCase):
     @classmethod


### PR DESCRIPTION
self.window expects to receive the arguments west, south, east, north,
so for positive e in affine we should swap top and bottom

fixes #76