### PR TITLE
Upgrade minimum rasterio version to 1.0 stable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'ipyleaflet!=0.8.2',
         'pyproj',
         'shapely>=1.6.3,<2.*',
-        'rasterio>=1.0b2',
+        'rasterio>=1.0,<2.*',
         'scipy',
         'pillow',
         'mercantile>=0.10.0',


### PR DESCRIPTION
Leaving this here only to check that all the tests pass. Luckily we did a good job fixing the deprecations and there's nothing special we have to do.