### PR TITLE
Fix deprecations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,11 @@ setup(
         'pyproj',
         'shapely>=1.6.3,<2.*',
         'rasterio>=1.0,<2.*',
-        'scipy',
         'pillow',
         'mercantile>=0.10.0',
         'matplotlib',
         'boltons',
+        'imageio',
     ],
     extras_require={
         ':python_version<="3.4"': ['typing', 'pandas<0.21.0'],

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -16,7 +16,7 @@ import mercantile
 import warnings
 
 import numpy as np
-import scipy.misc
+import imageio
 
 from boltons.setutils import IndexedSet
 
@@ -1177,10 +1177,10 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
                 img = np.stack([img, img, img], axis=2)  # make grayscale into rgb. bypass, as mode=LA isn't supported
 
             img = np.stack(tuple(np.split(np.asarray(img), 3, axis=2) + [mask]), axis=2)  # re-arrange into RGBA
-            img = Image.fromarray(img[:, :, :, 0])
+            img = img[:, :, :, 0]
 
         f = io.BytesIO()
-        scipy.misc.imsave(f, img, format)
+        imageio.imwrite(f, img, format)
         image_data = f.getvalue()
         return image_data
 
@@ -1194,7 +1194,7 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
         :param band_names: e.g. ['red', 'blue'] or 'red'
         """
         b = io.BytesIO(image_bytes)
-        image = scipy.misc.imread(b)
+        image = imageio.imread(b)
         roll = np.rollaxis(image, 2)
         if band_names is None:
             band_names = [0, 1, 2]

--- a/telluric/rasterization.py
+++ b/telluric/rasterization.py
@@ -30,9 +30,11 @@ def rasterize(shapes, crs, bounds=None, dest_resolution=None, *, fill_value=None
     if dtype is None:
         dtype = get_minimum_dtype(fill_value)
 
-    nodata_value = kwargs.get('nodata_value', NODATA_VALUE)
+    nodata_value = kwargs.get('nodata_value')
     if nodata_value is not None:
         warnings.warn(NODATA_DEPRECATION_WARNING, DeprecationWarning)
+    else:
+        nodata_value = NODATA_VALUE
 
     if not dest_resolution:
         raise ValueError("dest_resolution must be specified")

--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -13,6 +13,7 @@ from shapely.geometry import (
 from mercantile import Bbox, xy_bounds
 
 from rasterio.crs import CRS
+from typing import Tuple, Iterator
 
 from telluric.constants import DEFAULT_CRS, EQUAL_AREA_CRS, WGS84_CRS, WEB_MERCATOR_CRS
 from telluric.plotting import NotebookPlottingMixin
@@ -94,6 +95,7 @@ def get_dimension(geometry):
 
 
 def generate_tile_coordinates(roi, num_tiles):
+    # type: (GeoVector, Tuple[int, int]) -> Iterator[GeoVector]
     """Yields N x M rectangular tiles for a region of interest.
 
     Parameters
@@ -110,8 +112,8 @@ def generate_tile_coordinates(roi, num_tiles):
     """
     bounds = roi.get_shape(roi.crs).bounds
 
-    x_range = np.linspace(bounds[0], bounds[2], num_tiles[0] + 1)
-    y_range = np.linspace(bounds[1], bounds[3], num_tiles[1] + 1)
+    x_range = np.linspace(bounds[0], bounds[2], int(num_tiles[0]) + 1)
+    y_range = np.linspace(bounds[1], bounds[3], int(num_tiles[1]) + 1)
 
     for y_start, y_end in zip(y_range[:-1], y_range[1:]):
         for x_start, x_end in zip(x_range[:-1], x_range[1:]):


### PR DESCRIPTION
* Some image I/O functions in SciPy are being removed in the next version, see http://imageio.readthedocs.io/en/stable/scipy.html
* A float number of intervals was sometimes used in `np.linspace`
* An internal deprecation warning was always raised regardless of user input