### PR TITLE
Reprojection without loading data into memory

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -2,7 +2,6 @@ import json
 import os
 import io
 import contextlib
-import shutil
 from functools import reduce, partial
 from typing import Callable, Union, Iterable, Dict, List, Optional, Tuple
 from types import SimpleNamespace
@@ -671,7 +670,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             (self._image is None and self._filename is not None) and
             (tags is None and not kwargs)
         ):
-            shutil.copy(self._filename, filename)
+            rasterio.shutil.copy(self._filename, filename)
             self._cleanup()
             self._filename = filename
             return

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -671,9 +671,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             (self._image is None and self._filename is not None) and
             (tags is None and not kwargs)
         ):
-            # can be replaced with rasterio.shutil.copy in case
-            # we should pass creation_options while saving
-            shutil.copyfile(self._filename, filename)
+            shutil.copy(self._filename, filename)
             self._cleanup()
             self._filename = filename
             return
@@ -1167,8 +1165,6 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         ---------
         out: GeoRaster2
         """
-        dst_crs = dst_crs or self.crs
-
         if self._image is None and self._filename is not None:
             # image is not loaded yet
             with tempfile.NamedTemporaryFile(suffix='.tif', delete=False) as tf:
@@ -1184,7 +1180,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             src = SimpleNamespace(width=self.width, height=self.height, transform=self.transform, crs=self.crs,
                                   bounds=BoundingBox(*self.footprint().get_shape(self.crs).bounds),
                                   gcps=None)
-            dst_transform, dst_width, dst_height = calc_transform(
+            dst_crs, dst_transform, dst_width, dst_height = calc_transform(
                 src, dst_crs=dst_crs, resolution=resolution, dimensions=dimensions,
                 target_aligned_pixels=target_aligned_pixels,
                 src_bounds=src_bounds, dst_bounds=dst_bounds)

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1136,7 +1136,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         return new_raster
 
     def reproject(self, dst_crs=None, resolution=None, dimensions=None,
-                  src_bounds=None, dst_bounds=None,
+                  src_bounds=None, dst_bounds=None, target_aligned_pixels=False,
                   resampling=Resampling.cubic, creation_options=None, **kwargs):
         """Return re-projected raster to new raster.
 
@@ -1153,6 +1153,9 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             Georeferenced extent of output (in source georeferenced units).
         dst_bounds: tuple (xmin, ymin, xmax, ymax), optional
             Georeferenced extent of output (in destination georeferenced units).
+        target_aligned_pixels: bool, optional
+            Align the output bounds based on the resolution.
+            Default is `False`.
         resampling: rasterio.enums.Resampling
             Reprojection resampling method. Default is `cubic`.
         creation_options: dict, optional
@@ -1172,6 +1175,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                 warp(self._filename, tf.name, dst_crs=dst_crs, resolution=resolution,
                      dimensions=dimensions, creation_options=creation_options,
                      src_bounds=src_bounds, dst_bounds=dst_bounds,
+                     target_aligned_pixels=target_aligned_pixels,
                      resampling=resampling, **kwargs)
 
             new_raster = GeoRaster2(filename=tf.name, temporary=True)
@@ -1182,6 +1186,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                                   gcps=None)
             dst_transform, dst_width, dst_height = calc_transform(
                 src, dst_crs=dst_crs, resolution=resolution, dimensions=dimensions,
+                target_aligned_pixels=target_aligned_pixels,
                 src_bounds=src_bounds, dst_bounds=dst_bounds)
             new_raster = self._reproject(dst_width, dst_height, dst_transform,
                                          dst_crs=dst_crs, resampling=resampling)

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1177,6 +1177,8 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             new_raster = GeoRaster2(filename=tf.name, temporary=True)
         else:
             # image is loaded already
+            # SimpleNamespace is handy to hold the properties that calc_transform expects, see
+            # https://docs.python.org/3/library/types.html#types.SimpleNamespace
             src = SimpleNamespace(width=self.width, height=self.height, transform=self.transform, crs=self.crs,
                                   bounds=BoundingBox(*self.footprint().get_bounds(self.crs)),
                                   gcps=None)

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1178,7 +1178,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         else:
             # image is loaded already
             src = SimpleNamespace(width=self.width, height=self.height, transform=self.transform, crs=self.crs,
-                                  bounds=BoundingBox(*self.footprint().get_shape(self.crs).bounds),
+                                  bounds=BoundingBox(*self.footprint().get_bounds(self.crs)),
                                   gcps=None)
             dst_crs, dst_transform, dst_width, dst_height = calc_transform(
                 src, dst_crs=dst_crs, resolution=resolution, dimensions=dimensions,

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1136,17 +1136,33 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         return new_raster
 
     def reproject(self, dst_crs=None, resolution=None, dimensions=None,
+                  src_bounds=None, dst_bounds=None,
                   resampling=Resampling.cubic, creation_options=None, **kwargs):
         """Return re-projected raster to new raster.
 
-        :param dst_crs: new raster crs, default current crs
-        :param resolution: target resolution, in units of target crs
-        :param dimensions: output file size in pixels and lines
-        :param resampling: reprojection resampling method, default `cubic`
-        :param creation_options: custom creation options
-        :param kwargs: additional arguments passed to transformation function
+        Parameters
+        ------------
+        dst_crs: rasterio.crs.CRS, optional
+            Target coordinate reference system.
+        resolution: tuple (x resolution, y resolution) or float, optional
+            Target resolution, in units of target coordinate reference
+            system.
+        dimensions: tuple (width, height), optional
+            Output size in pixels and lines.
+        src_bounds: tuple (xmin, ymin, xmax, ymax), optional
+            Georeferenced extent of output (in source georeferenced units).
+        dst_bounds: tuple (xmin, ymin, xmax, ymax), optional
+            Georeferenced extent of output (in destination georeferenced units).
+        resampling: rasterio.enums.Resampling
+            Reprojection resampling method. Default is `cubic`.
+        creation_options: dict, optional
+            Custom creation options.
+        kwargs: optional
+            Additional arguments passed to transformation function.
 
-        :return GeoRaster2
+        Returns
+        ---------
+        out: GeoRaster2
         """
         dst_crs = dst_crs or self.crs
 
@@ -1155,6 +1171,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             with tempfile.NamedTemporaryFile(suffix='.tif', delete=False) as tf:
                 warp(self._filename, tf.name, dst_crs=dst_crs, resolution=resolution,
                      dimensions=dimensions, creation_options=creation_options,
+                     src_bounds=src_bounds, dst_bounds=dst_bounds,
                      resampling=resampling, **kwargs)
 
             new_raster = GeoRaster2(filename=tf.name, temporary=True)
@@ -1164,8 +1181,8 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                                   bounds=BoundingBox(*self.footprint().get_shape(self.crs).bounds),
                                   gcps=None)
             dst_transform, dst_width, dst_height = calc_transform(
-                src, dst_crs=dst_crs, resolution=resolution,
-                dimensions=dimensions)
+                src, dst_crs=dst_crs, resolution=resolution, dimensions=dimensions,
+                src_bounds=src_bounds, dst_bounds=dst_bounds)
             new_raster = self._reproject(dst_width, dst_height, dst_transform,
                                          dst_crs=dst_crs, resampling=resampling)
 

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -3,6 +3,7 @@ import rasterio
 import numpy as np
 from rasterio import shutil as rasterio_sh
 from rasterio.enums import Resampling, MaskFlags
+from rasterio.warp import calculate_default_transform
 from tempfile import TemporaryDirectory
 
 
@@ -83,3 +84,35 @@ def convert_to_cog(source_file, destination_file, resampling=Resampling.gauss):
             rasterio_sh.copy(temp_file, destination_file,
                              COPY_SRC_OVERVIEWS=True, tiled=True,
                              compress='DEFLATE', photometric='MINISBLACK')
+
+
+def reproject(source_file, destination_file, crs, resolution=None, creation_options=None, **kwargs):
+    """Reproject a source file to a destination file.
+
+    :param source_file: path to the original raster
+    :param destination_file: path to the new raster
+    :param crs: target coordinate reference system
+    :param resolution: target resolution, in units of target crs
+    :param creation_options: custom creation options
+    :param kwargs: additional arguments passed to transformation function
+    """
+    with rasterio.Env():
+        with rasterio.open(source_file) as src:
+            affine, width, height = calculate_default_transform(
+                src.crs, crs, src.width, src.height, *src.bounds,
+                resolution=resolution)
+
+            profile = src.profile.copy()
+            profile.update({
+                'crs': crs,
+                'transform': affine,
+                'width': width,
+                'height': height})
+            if creation_options is not None:
+                profile.update(creation_options)
+
+            with rasterio.open(destination_file, 'w', **profile) as dst:
+                rasterio.warp.reproject(
+                    rasterio.band(src, src.indexes),
+                    rasterio.band(dst, dst.indexes),
+                    **kwargs)

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -117,6 +117,8 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
 
     Returns
     -------
+    dst_crs: rasterio.crs.CRS
+        Output crs
     transform: Affine
         Output affine transformation matrix
     width, height: int
@@ -130,7 +132,7 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
 
     if target_aligned_pixels:
         if not resolution:
-            raise ValueError('target_aligned_pixels requires a specified resolution')
+            raise ValueError('target_aligned_pixels cannot be used without resolution')
         if src_bounds or dst_bounds:
             raise ValueError('target_aligned_pixels cannot be used with src_bounds or dst_bounds')
 
@@ -222,7 +224,7 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
         dst_transform, dst_width, dst_height = aligned_target(
             dst_transform, dst_width, dst_height, resolution)
 
-    return dst_transform, dst_width, dst_height
+    return dst_crs, dst_transform, dst_width, dst_height
 
 
 # Code was adapted from rasterio.rio.warp module
@@ -277,7 +279,7 @@ def warp(source_file, destination_file, dst_crs=None, resolution=None, dimension
     with rasterio.Env(CHECK_WITH_INVERT_PROJ=check_invert_proj):
         with rasterio.open(source_file) as src:
             out_kwargs = src.profile.copy()
-            dst_transform, dst_width, dst_height = calc_transform(
+            dst_crs, dst_transform, dst_width, dst_height = calc_transform(
                 src, dst_crs, resolution, dimensions,
                 src_bounds, dst_bounds, target_aligned_pixels)
 

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -90,6 +90,141 @@ def convert_to_cog(source_file, destination_file, resampling=Resampling.gauss):
                              compress='DEFLATE', photometric='MINISBLACK')
 
 
+def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
+                   src_bounds=None, dst_bounds=None, target_aligned_pixels=False):
+    """Output dimensions and transform for a reprojection.
+
+    Parameters
+    ------------
+    src: rasterio.io.DatasetReader
+        Data source.
+    dst_crs: rasterio.crs.CRS, optional
+        Target coordinate reference system.
+    resolution: tuple (x resolution, y resolution) or float, optional
+        Target resolution, in units of target coordinate reference
+        system.
+    dimensions: tuple (width, height), optional
+        Output file size in pixels and lines.
+    src_bounds: tuple (xmin, ymin, xmax, ymax), optional
+        Georeferenced extent of output file from source bounds
+        (in source georeferenced units).
+    dst_bounds: tuple (xmin, ymin, xmax, ymax), optional
+        Georeferenced extent of output file from destination bounds
+        (in destination georeferenced units).
+    target_aligned_pixels: bool, optional
+        Align the output bounds based on the resolution.
+        Default is `False`.
+
+    Returns
+    -------
+    transform: Affine
+        Output affine transformation matrix
+    width, height: int
+        Output dimensions
+    """
+    l, b, r, t = src.bounds
+
+    if resolution is not None:
+        if isinstance(resolution, (float, int)):
+            resolution = (float(resolution), float(resolution))
+
+    if target_aligned_pixels:
+        if not resolution:
+            raise ValueError('target_aligned_pixels requires a specified resolution')
+        if src_bounds or dst_bounds:
+            raise ValueError('target_aligned_pixels cannot be used with src_bounds or dst_bounds')
+
+    elif dimensions:
+        invalid_combos = (dst_bounds, resolution)
+        if any(p for p in invalid_combos if p is not None):
+            raise ValueError('dimensions cannot be used with dst_bounds or resolution')
+
+    if src_bounds and dst_bounds:
+        raise ValueError('src_bounds and dst_bounds may not be specified simultaneously')
+
+    if dst_crs is not None:
+
+        if dimensions:
+            # Calculate resolution appropriate for dimensions
+            # in target.
+            dst_width, dst_height = dimensions
+            xmin, ymin, xmax, ymax = transform_bounds(
+                src.crs, dst_crs, *src.bounds)
+            dst_transform = Affine(
+                (xmax - xmin) / float(dst_width),
+                0, xmin, 0,
+                (ymin - ymax) / float(dst_height),
+                ymax
+            )
+
+        elif src_bounds or dst_bounds:
+            if not resolution:
+                raise ValueError('resolution is required when using src_bounds or dst_bounds')
+
+            if src_bounds:
+                xmin, ymin, xmax, ymax = transform_bounds(
+                    src.crs, dst_crs, *src_bounds)
+            else:
+                xmin, ymin, xmax, ymax = dst_bounds
+
+            dst_transform = Affine(resolution[0], 0, xmin, 0, -resolution[1], ymax)
+            dst_width = max(int(ceil((xmax - xmin) / resolution[0])), 1)
+            dst_height = max(int(ceil((ymax - ymin) / resolution[1])), 1)
+
+        else:
+            if src.transform.is_identity and src.gcps:
+                src_crs = src.gcps[1]
+                kwargs = {'gcps': src.gcps[0]}
+            else:
+                src_crs = src.crs
+                kwargs = src.bounds._asdict()
+            dst_transform, dst_width, dst_height = calcdt(
+                src_crs, dst_crs, src.width, src.height,
+                resolution=resolution, **kwargs)
+
+    elif dimensions:
+        # Same projection, different dimensions, calculate resolution.
+        dst_crs = src.crs
+        dst_width, dst_height = dimensions
+        dst_transform = Affine(
+            (r - l) / float(dst_width),
+            0, l, 0,
+            (b - t) / float(dst_height),
+            t
+        )
+
+    elif src_bounds or dst_bounds:
+        # Same projection, different dimensions and possibly
+        # different resolution.
+        if not resolution:
+            resolution = (src.transform.a, -src.transform.e)
+
+        dst_crs = src.crs
+        xmin, ymin, xmax, ymax = (src_bounds or dst_bounds)
+        dst_transform = Affine(resolution[0], 0, xmin, 0, -resolution[1], ymax)
+        dst_width = max(int(ceil((xmax - xmin) / resolution[0])), 1)
+        dst_height = max(int(ceil((ymax - ymin) / resolution[1])), 1)
+
+    elif resolution:
+        # Same projection, different resolution.
+        dst_crs = src.crs
+        dst_transform = Affine(resolution[0], 0, l, 0, -resolution[1], t)
+        dst_width = max(int(ceil((r - l) / resolution[0])), 1)
+        dst_height = max(int(ceil((t - b) / resolution[1])), 1)
+
+    else:
+        dst_crs = src.crs
+        dst_transform = src.transform
+        dst_width = src.width
+        dst_height = src.height
+
+    if target_aligned_pixels:
+        dst_transform, dst_width, dst_height = aligned_target(
+            dst_transform, dst_width, dst_height, resolution)
+
+    return dst_transform, dst_width, dst_height
+
+
 # Code was adapted from rasterio.rio.warp module
 def warp(source_file, destination_file, dst_crs=None, resolution=None, dimensions=None,
          src_bounds=None, dst_bounds=None, src_nodata=None, dst_nodata=None,
@@ -139,108 +274,12 @@ def warp(source_file, destination_file, dst_crs=None, resolution=None, dimension
         Output is written to destination.
     """
 
-    res = resolution
-    if res is not None:
-        if isinstance(res, (float, int)):
-            res = (float(res), float(res))
-
-    if target_aligned_pixels:
-        if not res:
-            raise ValueError('target_aligned_pixels requires a specified resolution')
-        if src_bounds or dst_bounds:
-            raise ValueError('target_aligned_pixels cannot be used with src_bounds dst_bounds')
-
-    elif dimensions:
-        invalid_combos = (dst_bounds, res)
-        if any(p for p in invalid_combos if p is not None):
-            raise ValueError('dimensions cannot be used with dst_bounds or resolution')
-
-    if src_bounds and dst_bounds:
-        raise ValueError('src_bounds and dst_bounds may not be specified simultaneously')
-
     with rasterio.Env(CHECK_WITH_INVERT_PROJ=check_invert_proj):
         with rasterio.open(source_file) as src:
-            l, b, r, t = src.bounds
             out_kwargs = src.profile.copy()
-
-            if dst_crs is not None:
-
-                if dimensions:
-                    # Calculate resolution appropriate for dimensions
-                    # in target.
-                    dst_width, dst_height = dimensions
-                    xmin, ymin, xmax, ymax = transform_bounds(
-                        src.crs, dst_crs, *src.bounds)
-                    dst_transform = Affine(
-                        (xmax - xmin) / float(dst_width),
-                        0, xmin, 0,
-                        (ymin - ymax) / float(dst_height),
-                        ymax
-                    )
-
-                elif src_bounds or dst_bounds:
-                    if not res:
-                        raise ValueError('resolution is required when using src_bounds or dst_bounds')
-
-                    if src_bounds:
-                        xmin, ymin, xmax, ymax = transform_bounds(
-                            src.crs, dst_crs, *src_bounds)
-                    else:
-                        xmin, ymin, xmax, ymax = dst_bounds
-
-                    dst_transform = Affine(res[0], 0, xmin, 0, -res[1], ymax)
-                    dst_width = max(int(ceil((xmax - xmin) / res[0])), 1)
-                    dst_height = max(int(ceil((ymax - ymin) / res[1])), 1)
-
-                else:
-                    if src.transform.is_identity and src.gcps:
-                        src_crs = src.gcps[1]
-                        kwargs = {'gcps': src.gcps[0]}
-                    else:
-                        src_crs = src.crs
-                        kwargs = src.bounds._asdict()
-                    dst_transform, dst_width, dst_height = calcdt(
-                            src_crs, dst_crs, src.width, src.height,
-                            resolution=res, **kwargs)
-
-            elif dimensions:
-                # Same projection, different dimensions, calculate resolution.
-                dst_crs = src.crs
-                dst_width, dst_height = dimensions
-                dst_transform = Affine(
-                    (r - l) / float(dst_width),
-                    0, l, 0,
-                    (b - t) / float(dst_height),
-                    t
-                )
-
-            elif src_bounds or dst_bounds:
-                # Same projection, different dimensions and possibly
-                # different resolution.
-                if not res:
-                    res = (src.transform.a, -src.transform.e)
-
-                dst_crs = src.crs
-                xmin, ymin, xmax, ymax = (src_bounds or dst_bounds)
-                dst_transform = Affine(res[0], 0, xmin, 0, -res[1], ymax)
-                dst_width = max(int(ceil((xmax - xmin) / res[0])), 1)
-                dst_height = max(int(ceil((ymax - ymin) / res[1])), 1)
-
-            elif res:
-                # Same projection, different resolution.
-                dst_crs = src.crs
-                dst_transform = Affine(res[0], 0, l, 0, -res[1], t)
-                dst_width = max(int(ceil((r - l) / res[0])), 1)
-                dst_height = max(int(ceil((t - b) / res[1])), 1)
-
-            else:
-                dst_crs = src.crs
-                dst_transform = src.transform
-                dst_width = src.width
-                dst_height = src.height
-
-            if target_aligned_pixels:
-                dst_transform, dst_width, dst_height = aligned_target(dst_transform, dst_width, dst_height, res)
+            dst_transform, dst_width, dst_height = calc_transform(
+                src, dst_crs, resolution, dimensions,
+                src_bounds, dst_bounds, target_aligned_pixels)
 
             # If src_nodata is not None, update the dst metadata NODATA
             # value to src_nodata (will be overridden by dst_nodata if it is not None.

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -1,10 +1,14 @@
 import os
 import rasterio
 import numpy as np
+from affine import Affine
 from rasterio import shutil as rasterio_sh
 from rasterio.enums import Resampling, MaskFlags
-from rasterio.warp import calculate_default_transform
+from rasterio.warp import (
+    transform_bounds, reproject, aligned_target,
+    calculate_default_transform as calcdt)
 from tempfile import TemporaryDirectory
+from math import ceil
 
 
 def _calc_overviews_factors(one, blocksize=256):
@@ -86,33 +90,200 @@ def convert_to_cog(source_file, destination_file, resampling=Resampling.gauss):
                              compress='DEFLATE', photometric='MINISBLACK')
 
 
-def reproject(source_file, destination_file, crs, resolution=None, creation_options=None, **kwargs):
-    """Reproject a source file to a destination file.
+# Code was adapted from rasterio.rio.warp module
+def warp(source_file, destination_file, dst_crs=None, resolution=None, dimensions=None,
+         src_bounds=None, dst_bounds=None, src_nodata=None, dst_nodata=None,
+         target_aligned_pixels=False, check_invert_proj=True,
+         creation_options=None, resampling=Resampling.cubic, **kwargs):
+    """Warp a raster dataset.
 
-    :param source_file: path to the original raster
-    :param destination_file: path to the new raster
-    :param crs: target coordinate reference system
-    :param resolution: target resolution, in units of target crs
-    :param creation_options: custom creation options
-    :param kwargs: additional arguments passed to transformation function
+    Parameters
+    ------------
+    source_file: str, file object or pathlib.Path object
+        Source file.
+    destination_file: str, file object or pathlib.Path object
+        Destination file.
+    dst_crs: rasterio.crs.CRS, optional
+        Target coordinate reference system.
+    resolution: tuple (x resolution, y resolution) or float, optional
+        Target resolution, in units of target coordinate reference
+        system.
+    dimensions: tuple (width, height), optional
+        Output file size in pixels and lines.
+    src_bounds: tuple (xmin, ymin, xmax, ymax), optional
+        Georeferenced extent of output file from source bounds
+        (in source georeferenced units).
+    dst_bounds: tuple (xmin, ymin, xmax, ymax), optional
+        Georeferenced extent of output file from destination bounds
+        (in destination georeferenced units).
+    src_nodata: int, float, or nan, optional
+        Manually overridden source nodata.
+    dst_nodata: int, float, or nan, optional
+        Manually overridden destination nodata.
+    target_aligned_pixels: bool, optional
+        Align the output bounds based on the resolution.
+        Default is `False`.
+    check_invert_proj: bool, optional
+        Constrain output to valid coordinate region in dst_crs.
+        Default is `True`.
+    creation_options: dict, optional
+        Custom creation options.
+    resampling: rasterio.enums.Resampling
+        Reprojection resampling method. Default is `cubic`.
+    kwargs: optional
+        Additional arguments passed to transformation function.
+
+    Returns
+    ---------
+    out: None
+        Output is written to destination.
     """
-    with rasterio.Env():
+
+    res = resolution
+    if res is not None:
+        if isinstance(res, (float, int)):
+            res = (float(res), float(res))
+
+    if target_aligned_pixels:
+        if not res:
+            raise ValueError('target_aligned_pixels requires a specified resolution')
+        if src_bounds or dst_bounds:
+            raise ValueError('target_aligned_pixels cannot be used with src_bounds dst_bounds')
+
+    elif dimensions:
+        invalid_combos = (dst_bounds, res)
+        if any(p for p in invalid_combos if p is not None):
+            raise ValueError('dimensions cannot be used with dst_bounds or resolution')
+
+    if src_bounds and dst_bounds:
+        raise ValueError('src_bounds and dst_bounds may not be specified simultaneously')
+
+    with rasterio.Env(CHECK_WITH_INVERT_PROJ=check_invert_proj):
         with rasterio.open(source_file) as src:
-            affine, width, height = calculate_default_transform(
-                src.crs, crs, src.width, src.height, *src.bounds,
-                resolution=resolution)
+            l, b, r, t = src.bounds
+            out_kwargs = src.profile.copy()
 
-            profile = src.profile.copy()
-            profile.update({
-                'crs': crs,
-                'transform': affine,
-                'width': width,
-                'height': height})
+            if dst_crs is not None:
+
+                if dimensions:
+                    # Calculate resolution appropriate for dimensions
+                    # in target.
+                    dst_width, dst_height = dimensions
+                    xmin, ymin, xmax, ymax = transform_bounds(
+                        src.crs, dst_crs, *src.bounds)
+                    dst_transform = Affine(
+                        (xmax - xmin) / float(dst_width),
+                        0, xmin, 0,
+                        (ymin - ymax) / float(dst_height),
+                        ymax
+                    )
+
+                elif src_bounds or dst_bounds:
+                    if not res:
+                        raise ValueError('resolution is required when using src_bounds or dst_bounds')
+
+                    if src_bounds:
+                        xmin, ymin, xmax, ymax = transform_bounds(
+                            src.crs, dst_crs, *src_bounds)
+                    else:
+                        xmin, ymin, xmax, ymax = dst_bounds
+
+                    dst_transform = Affine(res[0], 0, xmin, 0, -res[1], ymax)
+                    dst_width = max(int(ceil((xmax - xmin) / res[0])), 1)
+                    dst_height = max(int(ceil((ymax - ymin) / res[1])), 1)
+
+                else:
+                    if src.transform.is_identity and src.gcps:
+                        src_crs = src.gcps[1]
+                        kwargs = {'gcps': src.gcps[0]}
+                    else:
+                        src_crs = src.crs
+                        kwargs = src.bounds._asdict()
+                    dst_transform, dst_width, dst_height = calcdt(
+                            src_crs, dst_crs, src.width, src.height,
+                            resolution=res, **kwargs)
+
+            elif dimensions:
+                # Same projection, different dimensions, calculate resolution.
+                dst_crs = src.crs
+                dst_width, dst_height = dimensions
+                dst_transform = Affine(
+                    (r - l) / float(dst_width),
+                    0, l, 0,
+                    (b - t) / float(dst_height),
+                    t
+                )
+
+            elif src_bounds or dst_bounds:
+                # Same projection, different dimensions and possibly
+                # different resolution.
+                if not res:
+                    res = (src.transform.a, -src.transform.e)
+
+                dst_crs = src.crs
+                xmin, ymin, xmax, ymax = (src_bounds or dst_bounds)
+                dst_transform = Affine(res[0], 0, xmin, 0, -res[1], ymax)
+                dst_width = max(int(ceil((xmax - xmin) / res[0])), 1)
+                dst_height = max(int(ceil((ymax - ymin) / res[1])), 1)
+
+            elif res:
+                # Same projection, different resolution.
+                dst_crs = src.crs
+                dst_transform = Affine(res[0], 0, l, 0, -res[1], t)
+                dst_width = max(int(ceil((r - l) / res[0])), 1)
+                dst_height = max(int(ceil((t - b) / res[1])), 1)
+
+            else:
+                dst_crs = src.crs
+                dst_transform = src.transform
+                dst_width = src.width
+                dst_height = src.height
+
+            if target_aligned_pixels:
+                dst_transform, dst_width, dst_height = aligned_target(dst_transform, dst_width, dst_height, res)
+
+            # If src_nodata is not None, update the dst metadata NODATA
+            # value to src_nodata (will be overridden by dst_nodata if it is not None.
+            if src_nodata is not None:
+                # Update the destination NODATA value
+                out_kwargs.update({
+                    'nodata': src_nodata
+                })
+
+            # Validate a manually set destination NODATA value.
+            if dst_nodata is not None:
+                if src_nodata is None and src.meta['nodata'] is None:
+                    raise ValueError('src_nodata must be provided because dst_nodata is not None')
+                else:
+                    out_kwargs.update({'nodata': dst_nodata})
+
+            out_kwargs.update({
+                'crs': dst_crs,
+                'transform': dst_transform,
+                'width': dst_width,
+                'height': dst_height
+            })
+
+            # Adjust block size if necessary.
+            if ('blockxsize' in out_kwargs and
+                    dst_width < out_kwargs['blockxsize']):
+                del out_kwargs['blockxsize']
+            if ('blockysize' in out_kwargs and
+                    dst_height < out_kwargs['blockysize']):
+                del out_kwargs['blockysize']
+
             if creation_options is not None:
-                profile.update(creation_options)
+                out_kwargs.update(**creation_options)
 
-            with rasterio.open(destination_file, 'w', **profile) as dst:
-                rasterio.warp.reproject(
-                    rasterio.band(src, src.indexes),
-                    rasterio.band(dst, dst.indexes),
+            with rasterio.open(destination_file, 'w', **out_kwargs) as dst:
+                reproject(
+                    source=rasterio.band(src, src.indexes),
+                    destination=rasterio.band(dst, dst.indexes),
+                    src_transform=src.transform,
+                    src_crs=src.crs,
+                    src_nodata=src_nodata,
+                    dst_transform=out_kwargs['transform'],
+                    dst_crs=out_kwargs['crs'],
+                    dst_nodata=dst_nodata,
+                    resampling=resampling,
                     **kwargs)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -668,6 +668,8 @@ def test_destructor():
 
 def test_save_temporary():
     with NamedTemporaryFile(suffix='.tif', delete=False) as src, NamedTemporaryFile(suffix='.tif') as dst:
+        # create valid raster file
+        some_raster.save(src.name)
         raster = GeoRaster2(filename=src.name, temporary=True)
         assert raster._filename == src.name
         assert raster._temporary

--- a/tests/test_georaster_reproject.py
+++ b/tests/test_georaster_reproject.py
@@ -1,0 +1,242 @@
+import pytest
+import numpy as np
+import rasterio
+
+from telluric import GeoRaster2
+from telluric.constants import WGS84_CRS
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_no_reproject(in_memory):
+    """ When called without parameters, output should be same as source """
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    expected_raster = raster.reproject()
+    assert expected_raster == raster
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_no_reproject_dimensions(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    expected_raster = raster.reproject(dimensions=(512, 512))
+    assert expected_raster.crs == raster.crs
+    assert expected_raster.width == 512
+    assert expected_raster.height == 512
+    assert np.allclose([14.929107, 14.929107],
+                       [expected_raster.transform.a, -expected_raster.transform.e])
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_no_reproject_resolution(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    expected_raster = raster.reproject(resolution=30)
+    assert expected_raster.crs == raster.crs
+    assert expected_raster.width == 255
+    assert expected_raster.height == 255
+    assert np.allclose([30, 30],
+                       [expected_raster.transform.a, -expected_raster.transform.e])
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_no_reproject_bounds(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    dst_bounds = [-6574000, -4077000, -6573000, -4076000]
+    expected_raster = raster.reproject(dst_bounds=dst_bounds)
+    expected_bounds = expected_raster.footprint().get_shape(expected_raster.crs).bounds
+    assert expected_raster.crs == raster.crs
+    assert expected_raster.width == 14
+    assert expected_raster.height == 14
+    assert np.allclose([raster.transform.a, raster.transform.e],
+                       [expected_raster.transform.a, expected_raster.transform.e])
+    assert np.allclose(expected_bounds[0::3], [-6574000, -4076000])
+
+    # XXX: an extra row and column is produced in the dataset
+    # because we are using ceil instead of floor
+    # (as rasterio does it internally).
+    psize = (expected_raster.transform.a, -expected_raster.transform.e)
+    assert np.allclose([expected_bounds[2] - psize[1], expected_bounds[1] + psize[0]],
+                       [-6573000, -4077000])
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_no_reproject_bounds_res(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    dst_bounds = [-6574000, -4077000, -6570000, -4073000]
+    resolution = 30
+    expected_raster = raster.reproject(dst_bounds=dst_bounds, resolution=resolution)
+    assert expected_raster.crs == raster.crs
+    assert expected_raster.width == 134
+    assert expected_raster.height == 134
+    assert np.allclose(
+        expected_raster.footprint().get_shape(expected_raster.crs).bounds,
+        dst_bounds)
+    assert np.allclose([30, 30],
+                       [expected_raster.transform.a, -expected_raster.transform.e])
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_reproject_dst_crs(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    expected_raster = raster.reproject(dst_crs=WGS84_CRS)
+    assert expected_raster.shape[0] == raster.shape[0]
+    assert expected_raster.crs == WGS84_CRS
+    assert expected_raster.width == 109
+    assert expected_raster.height == 90
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_reproject_resolution(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    resolution = 0.01
+    expected_raster = raster.reproject(dst_crs=WGS84_CRS, resolution=resolution)
+    assert expected_raster.crs == WGS84_CRS
+    assert expected_raster.width == 7
+    assert expected_raster.height == 6
+    assert np.allclose([resolution, resolution],
+                       [expected_raster.transform.a, -expected_raster.transform.e])
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_reproject_dimensions(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    dimensions = (100, 100)
+    expected_raster = raster.reproject(dst_crs=WGS84_CRS, dimensions=dimensions)
+    assert expected_raster.crs == WGS84_CRS
+    assert expected_raster.width == dimensions[0]
+    assert expected_raster.height == dimensions[1]
+    assert np.allclose([0.0006866455078125, 0.0005670066298468868],
+                       [expected_raster.transform.a, -expected_raster.transform.e])
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+@pytest.mark.parametrize("bad_params", [
+    {'resolution': 10},
+    {'dst_bounds': [0, 0, 10, 10]}
+])
+def test_warp_reproject_dimensions_invalid_params(in_memory, bad_params):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    dimensions = (100, 100)
+    with pytest.raises(ValueError) as error:
+        expected_raster = raster.reproject(
+            dst_crs=WGS84_CRS, dimensions=dimensions, **bad_params)
+    assert "dimensions cannot be used with" in error.exconly()
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_reproject_bounds_no_resolution(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    dst_bounds = [-11850000, 4810000, -11849000, 4812000]
+    with pytest.raises(ValueError) as error:
+        expected_raster = raster.reproject(
+            dst_crs=WGS84_CRS, dst_bounds=dst_bounds)
+    assert "resolution is required when using src_bounds or dst_bounds" in error.exconly()
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_reproject_multi_bounds_fail(in_memory):
+    """Mixing dst_bounds and src_bounds fails."""
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    dst_bounds = [-11850000, 4810000, -11849000, 4812000]
+    with pytest.raises(ValueError) as error:
+        expected_raster = raster.reproject(
+            dst_crs=WGS84_CRS, dst_bounds=dst_bounds, src_bounds=dst_bounds)
+    assert "src_bounds and dst_bounds may not be specified simultaneously" in error.exconly()
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_reproject_src_bounds_resolution(in_memory):
+    """src_bounds works."""
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    src_bounds = [-6574000, -4077000, -6570000, -4073000]
+    resolution = 0.001
+    expected_raster = raster.reproject(dst_crs=WGS84_CRS, src_bounds=src_bounds, resolution=resolution)
+    assert expected_raster.crs == WGS84_CRS
+    assert expected_raster.width == 36
+    assert expected_raster.height == 30
+    assert np.allclose([resolution, resolution],
+                       [expected_raster.transform.a, -expected_raster.transform.e])
+    assert np.allclose(expected_raster.footprint().get_shape(expected_raster.crs).bounds,
+                       [-59.05524, -34.35851, -59.01924, -34.32851])
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_reproject_dst_bounds(in_memory):
+    """dst_bounds works."""
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    dst_bounds = [-59.05437, -34.35519, -59.01042, -34.32627]
+    resolution = 0.001
+    expected_raster = raster.reproject(dst_crs=WGS84_CRS, dst_bounds=dst_bounds, resolution=resolution)
+    expected_bounds = expected_raster.footprint().get_shape(expected_raster.crs).bounds
+    assert expected_raster.crs == WGS84_CRS
+    assert expected_raster.width == 44
+    assert expected_raster.height == 29
+    assert np.allclose([resolution, resolution],
+                       [expected_raster.transform.a, -expected_raster.transform.e])
+    assert np.allclose(expected_raster.footprint().get_shape(expected_raster.crs).bounds,
+                       dst_bounds)
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+@pytest.mark.parametrize("bad_params", [
+    {},
+    {'src_bounds': [0, 0, 10, 10], 'resolution': 0.001},
+    {'dst_bounds': [0, 0, 10, 10], 'resolution': 0.001},
+])
+def test_warp_target_aligned_pixels_invalid_params(in_memory, bad_params):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    with pytest.raises(ValueError) as error:
+        expected_raster = raster.reproject(
+            dst_crs=WGS84_CRS, target_aligned_pixels=True, **bad_params)
+    assert "target_aligned_pixels cannot be used" in error.exconly()
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_target_aligned_pixels_true(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    resolution = 0.0001
+    raster1 = raster.reproject(dst_crs=WGS84_CRS, resolution=resolution,
+                               target_aligned_pixels=False)
+    raster2 = raster.reproject(dst_crs=WGS84_CRS, resolution=resolution,
+                               target_aligned_pixels=True)
+    assert raster1 != raster2
+
+
+def test_warp_reproject_creation_options():
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    tiled_raster = raster.reproject(
+        dst_crs=WGS84_CRS, dimensions=(1024, 1024), creation_options={'tiled': True})
+    non_tiled_raster = raster.reproject(
+        dst_crs=WGS84_CRS, dimensions=(1024, 1024), creation_options={'tiled': False})
+    with rasterio.open(tiled_raster._filename) as src:
+        assert src.profile['tiled']
+    with rasterio.open(non_tiled_raster._filename) as src:
+        assert not src.profile['tiled']

--- a/tests/test_georaster_reproject.py
+++ b/tests/test_georaster_reproject.py
@@ -49,7 +49,7 @@ def test_warp_no_reproject_bounds(in_memory):
         raster_image = raster.image
     dst_bounds = [-6574000, -4077000, -6573000, -4076000]
     expected_raster = raster.reproject(dst_bounds=dst_bounds)
-    expected_bounds = expected_raster.footprint().get_shape(expected_raster.crs).bounds
+    expected_bounds = expected_raster.footprint().get_bounds(expected_raster.crs)
     assert expected_raster.crs == raster.crs
     assert expected_raster.width == 14
     assert expected_raster.height == 14
@@ -77,7 +77,7 @@ def test_warp_no_reproject_bounds_res(in_memory):
     assert expected_raster.width == 134
     assert expected_raster.height == 134
     assert np.allclose(
-        expected_raster.footprint().get_shape(expected_raster.crs).bounds,
+        expected_raster.footprint().get_bounds(expected_raster.crs),
         dst_bounds)
     assert np.allclose([30, 30],
                        [expected_raster.transform.a, -expected_raster.transform.e])
@@ -178,7 +178,7 @@ def test_warp_reproject_src_bounds_resolution(in_memory):
     assert expected_raster.height == 30
     assert np.allclose([resolution, resolution],
                        [expected_raster.transform.a, -expected_raster.transform.e])
-    assert np.allclose(expected_raster.footprint().get_shape(expected_raster.crs).bounds,
+    assert np.allclose(expected_raster.footprint().get_bounds(expected_raster.crs),
                        [-59.05524, -34.35851, -59.01924, -34.32851])
 
 
@@ -191,13 +191,13 @@ def test_warp_reproject_dst_bounds(in_memory):
     dst_bounds = [-59.05437, -34.35519, -59.01042, -34.32627]
     resolution = 0.001
     expected_raster = raster.reproject(dst_crs=WGS84_CRS, dst_bounds=dst_bounds, resolution=resolution)
-    expected_bounds = expected_raster.footprint().get_shape(expected_raster.crs).bounds
+    expected_bounds = expected_raster.footprint().get_bounds(expected_raster.crs)
     assert expected_raster.crs == WGS84_CRS
     assert expected_raster.width == 44
     assert expected_raster.height == 29
     assert np.allclose([resolution, resolution],
                        [expected_raster.transform.a, -expected_raster.transform.e])
-    assert np.allclose(expected_raster.footprint().get_shape(expected_raster.crs).bounds,
+    assert np.allclose(expected_raster.footprint().get_bounds(expected_raster.crs),
                        dst_bounds)
 
 


### PR DESCRIPTION
* New `telluric.util.raster_utils.reproject` function for reprojecting files
* New option `temporary` for `GeoRaster2.__init__`, default is False
* Consider `GeoRaster2` instance `obj`. If `obj._image is None` and `obj._filename is not None` then `obj.reproject` produces new `GeoRaster2` instance with property `temporary=True` and `_filename` referenced to resulted file.
* New `_cleanup` method `GeoRaster2`. It is called in two places: within `__del__` and within `save`
* New `creation_options` argument of `GeoRaster2.reproject`
* New `**kwargs` argument of `GeoRaster2.reproject`, can be used for passing such options as `num_threads` or `warp_mem_limit` to transformation function

- [x] unit tests
- [x] add the same option to `reproject` function as `-ts width height` in `gdalwarp`