### PR TITLE
Restore support for GET parameters in URLs

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1587,8 +1587,6 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
                 'GDAL_DISABLE_READDIR_ON_OPEN': True,
                 'GDAL_TIFF_INTERNAL_MASK_TO_8BIT': False,
             }   # type: Dict
-            if self._filename.split('.')[-1] == 'tif':
-                rasterio_env['CPL_VSIL_CURL_ALLOWED_EXTENSIONS'] = '.tif'
 
             with rasterio.Env(**rasterio_env):
                 with self._raster_opener(self._filename) as raster:  # type: rasterio.io.DatasetReader


### PR DESCRIPTION
This partially reverts commit f71a3350e110ae82ae5bda57f820eb1bb520e19d, bringing back support for get parameters in remote urls. Before adding a proper test, @arielze what was the reason for this particular change? Does this pull request break something that I'm not aware of?