### PR TITLE
Allow src_bounds to override src.bounds

### DIFF
--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -154,8 +154,9 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
             # Calculate resolution appropriate for dimensions
             # in target.
             dst_width, dst_height = dimensions
+            bounds = src_bounds or src.bounds
             xmin, ymin, xmax, ymax = transform_bounds(
-                src.crs, dst_crs, *src.bounds)
+                src.crs, dst_crs, *bounds)
             dst_transform = Affine(
                 (xmax - xmin) / float(dst_width),
                 0, xmin, 0,
@@ -192,6 +193,7 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
         # Same projection, different dimensions, calculate resolution.
         dst_crs = src.crs
         dst_width, dst_height = dimensions
+        l, b, r, t = src_bounds or (l, b, r, t)
         dst_transform = Affine(
             (r - l) / float(dst_width),
             0, l, 0,

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -128,8 +128,6 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
     width, height: int
         Output dimensions
     """
-    l, b, r, t = src.bounds
-
     if resolution is not None:
         if isinstance(resolution, (float, int)):
             resolution = (float(resolution), float(resolution))
@@ -193,7 +191,7 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
         # Same projection, different dimensions, calculate resolution.
         dst_crs = src.crs
         dst_width, dst_height = dimensions
-        l, b, r, t = src_bounds or (l, b, r, t)
+        l, b, r, t = src_bounds or src.bounds
         dst_transform = Affine(
             (r - l) / float(dst_width),
             0, l, 0,
@@ -216,6 +214,7 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
     elif resolution:
         # Same projection, different resolution.
         dst_crs = src.crs
+        l, b, r, t = src.bounds
         dst_transform = Affine(resolution[0], 0, l, 0, -resolution[1], t)
         dst_width = max(int(ceil((r - l) / resolution[0])), 1)
         dst_height = max(int(ceil((t - b) / resolution[1])), 1)

--- a/tests/test_georaster_reproject.py
+++ b/tests/test_georaster_reproject.py
@@ -84,6 +84,23 @@ def test_warp_no_reproject_bounds_res(in_memory):
 
 
 @pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_no_reproject_src_bounds_dimensions(in_memory):
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    src_bounds = [-6575538, -4078737, -6565840, -4069351]
+    dimensions = (1024, 1024)
+    expected_raster = raster.reproject(src_bounds=src_bounds, dimensions=dimensions)
+    bounds = expected_raster.footprint().get_bounds(raster.crs)
+    assert expected_raster.crs == raster.crs
+    assert np.allclose(bounds, src_bounds)
+    assert np.allclose([9.470703, 9.166015],
+                       [expected_raster.transform.a, -expected_raster.transform.e])
+    assert expected_raster.width == dimensions[0]
+    assert expected_raster.height == dimensions[1]
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
 def test_warp_reproject_dst_crs(in_memory):
     raster = GeoRaster2.open("tests/data/raster/rgb.tif")
     if in_memory:
@@ -180,6 +197,25 @@ def test_warp_reproject_src_bounds_resolution(in_memory):
                        [expected_raster.transform.a, -expected_raster.transform.e])
     assert np.allclose(expected_raster.footprint().get_bounds(expected_raster.crs),
                        [-59.05524, -34.35851, -59.01924, -34.32851])
+
+
+@pytest.mark.parametrize("in_memory", [True, False])
+def test_warp_reproject_src_bounds_dimensions(in_memory):
+    """src-bounds works with dimensions."""
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif")
+    if in_memory:
+        raster_image = raster.image
+    src_bounds = [-6575538, -4078737, -6565840, -4069351]
+    dimensions = (1024, 1024)
+    expected_raster = raster.reproject(dst_crs=WGS84_CRS, src_bounds=src_bounds, dimensions=dimensions)
+    bounds = expected_raster.footprint().get_bounds(expected_raster.crs)
+    assert expected_raster.crs == WGS84_CRS
+    assert expected_raster.width == dimensions[0]
+    assert expected_raster.height == dimensions[1]
+    assert np.allclose(bounds[:],
+                       [-59.06906, -34.37106, -58.98194, -34.30144])
+    assert round(expected_raster.transform.a, 4) == 0.0001
+    assert round(-expected_raster.transform.e, 4) == 0.0001
 
 
 @pytest.mark.parametrize("in_memory", [True, False])


### PR DESCRIPTION
The `dimensions` and `src-bounds` options can be used together. For details see issue [#1418](https://github.com/mapbox/rasterio/issues/1418). When this PR is merged we'll be able to rewrite this part: https://github.com/satellogic/telluric/blob/b56040d8b0884957f8f08934990cef5e2de402fd/telluric/util/tileserver_utils.py#L43-L44

in this way:

```
dimensions = (65536, 65536) # just for example
src_bounds=tl.GeoVector.from_xyz(tile.x, tile.y, tile.z).get_bounds(src_raster.crs)
warp(src, temp_file, dst_crs=tl.constants.WEB_MERCATOR_CRS, dimensions=dimensions, 
         src_bounds=src_bounds, create_options=create_options)
```

In this case, we can guarantee that the output image will be exactly square. Using the previous version we often get something like `(65537, 65536)`.