### PR TITLE
fixed a bug in get_tile affine calculation

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1624,7 +1624,7 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
         # we know the affine the result should produce becuase we know where
         # it is located by the xyz, therefore we calculate it here
         ratio = MERCATOR_RESOLUTION_MAPPING[zoom] / self.resolution()
-        
+
         # the affine should be calculated before rounding the window values
         affine = self.window_transform(window)
         affine = affine * Affine.scale(ratio, ratio)


### PR DESCRIPTION
Affine was calculated from a rounded widow which causes in some cases a single pixel offset of the affine in one or both axes.