### PR TITLE
adding Raster as a feature

### DIFF
--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -433,7 +433,7 @@ class FeatureCollection(BaseCollection):
     def from_record(cls, record, crs):
         features = record.get("features", [])
         features = [GeoFeature.from_record(f, crs) for f in features]
-        return FeatureCollection(features)
+        return cls(features)
 
     def _adapt_feature_before_write(self, feature):
         new_properties = feature.properties.copy()

--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -431,7 +431,7 @@ class FeatureCollection(BaseCollection):
 
     @classmethod
     def from_record(cls, record, crs):
-        features = record.get("features",[])
+        features = record.get("features", [])
         features = [GeoFeature.from_record(f, crs) for f in features]
         return FeatureCollection(features)
 

--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -429,6 +429,12 @@ class FeatureCollection(BaseCollection):
         """Builds new FeatureCollection from a sequence of :py:class:`~telluric.vectors.GeoVector` objects."""
         return cls([GeoFeature(vector, {}) for vector in geovectors])
 
+    @classmethod
+    def from_record(cls, record, crs):
+        features = record.get("features",[])
+        features = [GeoFeature.from_record(f, crs) for f in features]
+        return FeatureCollection(features)
+
     def _adapt_feature_before_write(self, feature):
         new_properties = feature.properties.copy()
         for key in self.property_names:

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -12,7 +12,6 @@ from telluric.vectors import (
 )
 from telluric.plotting import NotebookPlottingMixin
 from telluric import GeoRaster2
-from datetime import datetime as _datetime
 
 
 def telluric_key(key):

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -66,8 +66,8 @@ def raster_from_assets(assets):
     """
     raster = None
     for key, val in assets.items():
-        href = val.get("href", None)
-        bands = val.get("bands", None)
+        href = val.get("href")
+        bands = val.get("bands")
         if href:
             raster = GeoRaster2.open(href, band_names=bands)
             break

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -58,7 +58,7 @@ def serialize_properties(properties):
     return new_properties
 
 
-def from_assets(assets):
+def raster_from_assets(assets):
     """ create a raster from assets, assets is a dictonary of links like described
         in the stacs inteface https://github.com/radiantearth/stac-spec/tree/master/json-spec/examples
 
@@ -74,7 +74,7 @@ def from_assets(assets):
     return raster
 
 
-def to_assets(raster):
+def raster_to_assets(raster):
     return {"0": {"href": raster._filename, "bands": raster.band_names}}
 
 
@@ -130,7 +130,7 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
             properties = transform_properties(record["properties"], schema)
         else:
             properties = record["properties"]
-        raster = from_assets(record.get("raster", {}))
+        raster = raster_from_assets(record.get("raster", {}))
         if raster is not None:
             return GeoFeatureWithRaster(raster, properties)
         vector = GeoVector(
@@ -306,7 +306,7 @@ class GeoFeatureWithRaster(GeoFeature):
             'type': 'Feature',
             'properties': serialize_properties(self.properties),
             'geometry': self.geometry.to_record(crs),
-            'raster': to_assets(self.raster)
+            'raster': raster_to_assets(self.raster)
         }
         return ret_val
 

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -165,7 +165,7 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
         Parameters
         ----------
         raster : GeoRaster
-            Geometry.
+            the raster in the feature
         properties : dict
             Properties.
         """

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -68,7 +68,8 @@ def serialize_properties(properties):
             valid_assets[key] = {"href": asset._filename}
         else:
             warnings.warn("currenly we support only serilzation of GeoRaster objects that came from urls")
-    new_properties[telluric_key("assets")] = valid_assets
+    if len(valid_assets) > 0:
+        new_properties[telluric_key("assets")] = valid_assets
     return new_properties
 
 

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -125,7 +125,7 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
         return ret_val
 
     @classmethod
-    def get_class_from_record(cls, record):
+    def _get_class_from_record(cls, record):
         if "raster" in record:
             return GeoFeatureWithRaster
         else:
@@ -133,7 +133,7 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
 
     @classmethod
     def from_record(cls, record, crs, schema=None):
-        _cls = cls.get_class_from_record(record)
+        _cls = cls._get_class_from_record(record)
         return _cls._from_record(record, crs, schema)
 
     @classmethod

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -298,7 +298,7 @@ class GeoFeatureWithRaster(GeoFeature):
         if self.raster._filename is None:
             raise NotImplementedError("Supporting raster that are stored on disk or network")
         if self.raster.crs != crs:
-            raise NotImplementedError("Supporting serialzation of rasters without reprojection")
+            warnings.warn("Raster is not being reprojected to the crs")
         ret_val = {
             'type': 'Feature',
             'properties': serialize_properties(self.properties),

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -58,6 +58,34 @@ def serialize_properties(properties):
     return new_properties
 
 
+class GeoFeatureRaster():
+
+    def __init__(self, raster, properties):
+        self.properties = properties
+        self.raster = raster
+
+    @property
+    def crs(self):
+        return self.raster.crs
+
+    def to_record(self, crs=None):
+        if crs is None:
+            crs = self.crs
+
+        if self.raster._image is None:
+            raise NotImplementedError("to_recod on in memory raster is not implemeted yet")
+        if crs != self.crs:
+            raise NotImplementedError("to_record when reproject is required not implemeted yet")
+
+        self.properties["raster_url"] = self.raster._filename
+
+        return {
+            'type': 'Feature',
+            'properties': serialize_properties(self.properties),
+            'geometry': None,
+        }
+
+
 class GeoFeature(Mapping, NotebookPlottingMixin):
     """GeoFeature object.
 
@@ -102,6 +130,20 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
             'properties': serialize_properties(self.properties),
             'geometry': self.geometry.to_record(crs),
         }
+
+    @classmethod
+    def from_raster(cls, raster, properties):
+        """Initialize a GeoFeature object with a GeoRaster
+
+        Parameters
+        ----------
+        raster : GeoRaster
+            Geometry.
+        properties : dict
+            Properties.
+
+        """
+        return GeoFeatureRaster(raster, properties)
 
     @classmethod
     def from_record(cls, record, crs, schema=None):

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -14,10 +14,6 @@ from telluric.plotting import NotebookPlottingMixin
 from telluric import GeoRaster2
 
 
-def telluric_key(key):
-    return "tl:%s" % key
-
-
 def transform_properties(properties, schema):
     """Transform properties types according to a schema.
 

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -57,6 +57,7 @@ def serialize_properties(properties):
             new_properties[attr_name] = str(attr_value)
     return new_properties
 
+
 def from_assets(assets):
     """ create a raster from assets, assets is a dictonary of links like described
         in the stacs inteface https://github.com/radiantearth/stac-spec/tree/master/json-spec/examples
@@ -72,8 +73,10 @@ def from_assets(assets):
             break
     return raster
 
+
 def to_assets(raster):
     return {"0": {"href": raster._filename, "bands": raster.band_names}}
+
 
 class GeoFeature(Mapping, NotebookPlottingMixin):
     """GeoFeature object.
@@ -303,10 +306,9 @@ class GeoFeatureWithRaster(GeoFeature):
             'type': 'Feature',
             'properties': serialize_properties(self.properties),
             'geometry': self.geometry.to_record(crs),
-            'raster' : to_assets(self.raster)
+            'raster': to_assets(self.raster)
         }
         return ret_val
 
     def reproject(self, *args, **kwargs):
         raise NotImplementedError()
-

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -65,7 +65,9 @@ def serialize_properties(properties):
     valid_assets = {}
     for key, asset in assets.items():
         if isinstance(asset, GeoRaster2) and asset._filename is not None:
-            valid_assets[key] = {"href": asset._filename}
+            valid_assets[key] = {"href": asset._filename,
+                                 "bands": asset.band_names
+                                 }
         else:
             warnings.warn("currenly we support only serilzation of GeoRaster objects that came from urls")
     if len(valid_assets) > 0:

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -124,8 +124,8 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
         }
         return ret_val
 
-    @classmethod
-    def _get_class_from_record(cls, record):
+    @staticmethod
+    def _get_class_from_record(record):
         if "raster" in record:
             return GeoFeatureWithRaster
         else:
@@ -136,8 +136,8 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
         _cls = cls._get_class_from_record(record)
         return _cls._from_record(record, crs, schema)
 
-    @classmethod
-    def _to_properties(cls, record, schema):
+    @staticmethod
+    def _to_properties(record, schema):
         if schema is not None:
             properties = transform_properties(record["properties"], schema)
         else:

--- a/telluric/features.py
+++ b/telluric/features.py
@@ -59,19 +59,6 @@ def serialize_properties(properties):
             # https://docs.python.org/3.4/library/json.html#json.JSONEncoder
             # so we convert to string
             new_properties[attr_name] = str(attr_value)
-
-    # ###HACK####
-    assets = new_properties.pop(telluric_key("assets"), {})
-    valid_assets = {}
-    for key, asset in assets.items():
-        if isinstance(asset, GeoRaster2) and asset._filename is not None:
-            valid_assets[key] = {"href": asset._filename,
-                                 "bands": asset.band_names
-                                 }
-        else:
-            warnings.warn("currenly we support only serilzation of GeoRaster objects that came from urls")
-    if len(valid_assets) > 0:
-        new_properties[telluric_key("assets")] = valid_assets
     return new_properties
 
 def from_assets(assets):
@@ -96,7 +83,7 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
     """GeoFeature object.
 
     """
-    def __init__(self, geovector, properties, extension=None):
+    def __init__(self, geovector, properties):
         """Initialize a GeoFeature object.
 
         Parameters
@@ -105,10 +92,6 @@ class GeoFeature(Mapping, NotebookPlottingMixin):
             Geometry.
         properties : dict
             Properties.
-        assets : dict
-            Assets that are related to the feature,
-        datetime : Datetime or str
-            The datetime closest to the time the feature was generated, if not provided assume now
         """
 
         self.geometry = geovector  # type: GeoVector

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from affine import Affine
 import telluric as tl
 from telluric.constants import WEB_MERCATOR_CRS
 import pytest
+from rasterio.crs import CRS
 
 
 @pytest.fixture(scope="module")
@@ -10,7 +11,7 @@ def test_raster_with_no_url():
     raster = tl.GeoRaster2(np.random.uniform(0, 256, (3, 391, 370)),
                            affine=Affine(1.0000252884112817, 0.0, 2653750.345511198,
                                          0.0, -1.0000599330133702, 4594461.485763356),
-                           crs={'init': 'epsg:3857'})
+                           crs=CRS({'init': 'epsg:3857'}))
     return raster
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,13 @@ import telluric as tl
 from telluric.constants import WEB_MERCATOR_CRS
 import pytest
 
+
 @pytest.fixture(scope="module")
 def test_raster_with_no_url():
     raster = tl.GeoRaster2(np.random.uniform(0, 256, (3, 391, 370)),
-                        affine=Affine(1.0000252884112817, 0.0, 2653750.345511198,
-                                      0.0, -1.0000599330133702, 4594461.485763356),
-                        crs={'init': 'epsg:3857'})
+                           affine=Affine(1.0000252884112817, 0.0, 2653750.345511198,
+                                         0.0, -1.0000599330133702, 4594461.485763356),
+                           crs={'init': 'epsg:3857'})
     return raster
 
 
@@ -19,4 +20,3 @@ def test_raster_with_url(test_raster_with_no_url):
     url = "/vsimem/features.tif"
     raster.save(url)
     return tl.GeoRaster2.open(url)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import numpy as np
+from affine import Affine
+import telluric as tl
+from telluric.constants import WEB_MERCATOR_CRS
+import pytest
+
+@pytest.fixture(scope="module")
+def test_raster_with_no_url():
+    raster = tl.GeoRaster2(np.random.uniform(0, 256, (3, 391, 370)),
+                        affine=Affine(1.0000252884112817, 0.0, 2653750.345511198,
+                                      0.0, -1.0000599330133702, 4594461.485763356),
+                        crs={'init': 'epsg:3857'})
+    return raster
+
+
+@pytest.fixture(scope="module")
+def test_raster_with_url(test_raster_with_no_url):
+    raster = test_raster_with_no_url
+    url = "/vsimem/features.tif"
+    raster.save(url)
+    return tl.GeoRaster2.open(url)
+

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -461,3 +461,16 @@ def test_collection_add():
         == (gv1 + gv2 + gv3 + gv4)
         == FeatureCollection.from_geovectors([gv1, gv2, gv3, gv4])
     )
+
+
+def test_feature_collection_to_record_from_record():
+    num_features = 3
+    gen_features = (
+        GeoFeature.from_shape(
+            Polygon([(0 + d_x, 0), (0 + d_x, 1), (1 + d_x, 1), (1 + d_x, 0)])
+        )
+        for d_x in range(num_features)
+    )
+    fc = FeatureCollection(gen_features)
+
+    assert mapping(fc) == mapping(FeatureCollection.from_record(fc.to_record(WGS84_CRS), WGS84_CRS))

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -191,6 +191,7 @@ def test_geofeature_correctly_serializes_non_simple_types():
 
     assert mapping(feature)['properties'] == expected_properties
 
+
 @pytest.mark.parametrize("raster", [
     "test_raster_with_url", "test_raster_with_no_url"
 ])
@@ -201,6 +202,7 @@ def test_geofeature_from_raster_returns_a_valid_feature(raster, request):
     assert feature.properties == properties
     assert feature.raster == raster
     assert feature.raster.footprint() == feature.geometry
+
 
 @pytest.mark.parametrize("raster", [
     "test_raster_with_url"


### PR DESCRIPTION
We need to be able to add rasters to feature, 

I created a new class called `GeoFeatureWithRaster` that extend `GeoFeature`

It has additional attribute called raster, and the geometry is the footprint of the raster.

So it works the same as `GeoFeature` except for:
1. reporoject = we should apply GeoRaster reproject and not geometry reproject
2. to_record = we should serialzie to a [stac](https://github.com/radiantearth/stac-spec/blob/master/json-spec/json-spec.md#specification-description) complaint way  
3. FeatureCollection rasterize - should do merge instead of rasterzing the vectors

Problems:
`FileCollection.save`/`FileCollection.open()` don't work because fiona doesn't support GeoJson with foreign members, therefore I added a callmethod to featureCollection `from_record` so one could run the following code
```python
json.dumps("fc.json", fc.to_record(crs))
fc = FeatureCollection.from_record(json.loads("fc.json"), crs)
```





