### PR TITLE
Fix masking areas for merge_all

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'ipyleaflet!=0.8.2',
         'pyproj',
         'shapely>=1.6.3,<2.*',
-        'rasterio>=1.0,<2.*',
+        'rasterio>=1.0,<1.0.3',
         'pillow',
         'mercantile>=0.10.0',
         'matplotlib',


### PR DESCRIPTION
Using `reproject` without previous `crop` brings back issue of rasterization of adjacent rasters. 