### PR TITLE
adding a way to set the crs of a vector

### DIFF
--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -470,21 +470,24 @@ class FileCollection(BaseCollection):
         )
 
     @classmethod
-    def open(cls, filename):
+    def open(cls, filename, crs=None):
         """Creates a FileCollection from a file in disk.
 
         Parameters
         ----------
         filename : str
             Path of the file to read.
+        crs : CRS
+            overrides the crs of the collection, this funtion will not reprojects
 
         """
         with fiona.open(filename, 'r') as source:
-            crs = CRS(source.crs)
+            original_crs = CRS(source.crs)
             schema = source.schema
             length = len(source)
-
-        return cls(filename, crs, schema, length)
+        crs = crs or original_crs
+        ret_val = cls(filename, crs, schema, length)
+        return ret_val
 
     @property
     def crs(self):
@@ -500,7 +503,7 @@ class FileCollection(BaseCollection):
     def __iter__(self):
         with fiona.open(self._filename, 'r') as source:
             for record in source:
-                yield GeoFeature.from_record(record, source.crs, source.schema)
+                yield GeoFeature.from_record(record, self.crs, source.schema)
 
     def __getitem__(self, index):
         # See https://github.com/Toblerity/Fiona/issues/327 for discussion

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -296,6 +296,13 @@ def test_file_collection_open_save_shapefile():
         assert fcol == fcol_res.reproject(fcol.crs)
 
 
+def test_file_collection_open_shapefile_with_no_proj():
+    fcol = FileCollection.open("tests/data/vector/creaf/42112_noprj/42112.shp", crs=WGS84_CRS)[:10]
+    assert fcol.crs == WGS84_CRS
+    for feature in fcol:
+        assert feature.crs == WGS84_CRS
+
+
 def test_feature_collection_with_dates_serializes_correctly():
     # "For Shapefiles, however, the only possible field type is 'date' as 'datetime' and 'time' are not available."
     # https://github.com/Toblerity/Fiona/pull/130


### PR DESCRIPTION
There could be shape files that don't have the `.proj` fiona still opens them

Telluirc fails on many methods since the crs is not defined, so I added a way to codely add CRS