### PR TITLE
The right way of calculating dest_resolution

### DIFF
--- a/tests/test_merge_all.py
+++ b/tests/test_merge_all.py
@@ -497,3 +497,8 @@ def test_merge_all_different_crs():
     assert(result_1.crs == expected_crs)
     assert(result_1.footprint().envelope.almost_equals(roi.envelope, decimal=3))
     assert(result_0 == result_1)
+
+    # preserve the original resolution if dest_resolution is not provided
+    raster_2 = make_test_raster(1, [1], height=1200, width=1200, affine=affine, crs=WGS84_CRS)
+    result_2 = merge_all([raster_2], roi=roi, crs=expected_crs)
+    assert pytest.approx(result_2.resolution()) == 97.9691


### PR DESCRIPTION
In the current state if we are trying to merge multiple rasters without providing value of `dest_resolution` telluric get it as: https://github.com/satellogic/telluric/blob/fc2641205964b94bdfa4f986b805c7901a41764a/telluric/georaster.py#L95

This is not a right way to calculate the destination resolution in this case. For example, if original raster (the first one in the list passed to merge_all) has EPSG:4326 and resolution 0.05 degrees per pixel but output CRS is Web Mercator then telluric applies this resolution (0.05) to output image and fails with error:

```
telluric.rasterization.ScaleError: Scale is too fine, increase it for a smaller image
```

This PR is meant to overcome this issue.