### PR TITLE
Fix matplotlib error

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -47,7 +47,7 @@ from telluric.util.raster_utils import (
 from telluric.util.local_tile_server import TileServer
 
 # for mypy
-import matplotlib
+import matplotlib.cm
 from typing import Callable, Union, Iterable, Dict, List, Optional, Tuple
 
 dtype_map = {


### PR DESCRIPTION
```
In [1]: import matplotlib                                                                                                                                                                                           

In [2]: matplotlib.cm                                                                                                                                                                                               
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-acd131dfcaa3> in <module>
----> 1 matplotlib.cm

AttributeError: module 'matplotlib' has no attribute 'cm'

In [3]: import matplotlib.cm                                                                                                                                                                                        

In [4]: matplotlib.cm                                                                                                                                                                                               
Out[4]: <module 'matplotlib.cm' from '/home/denis/satellogic/env/lib/python3.6/site-packages/matplotlib/cm.py'>
```
