### PR TITLE
Use resource_filename to obtain a filename for gdalvrt.xsd

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include versioneer.py
 include telluric/_version.py
+include telluric/gdalvrt.xsd
 include LICENSE

--- a/telluric/base_vrt.py
+++ b/telluric/base_vrt.py
@@ -5,6 +5,7 @@ import lxml.etree as ET
 from xml.dom import minidom
 from rasterio.dtypes import _gdal_typename, check_dtype
 from rasterio.path import parse_path, vsi_path
+from pkg_resources import resource_filename
 
 
 def prettify(elem):
@@ -16,7 +17,7 @@ def prettify(elem):
 
 
 def load_scheme():
-    with open('./telluric/gdalvrt.xsd') as f:
+    with open(resource_filename('telluric', 'gdalvrt.xsd')) as f:
         scheme_doc = ET.parse(f)
         return ET.XMLSchema(scheme_doc)
 


### PR DESCRIPTION
Fix for the following issue:

```
FileNotFoundError: [Errno 2] No such file or directory: './telluric/gdalvrt.xsd'
```