### PR TITLE
Save should work on GeoRaster that were used by open to save as well

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -636,7 +636,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             self._temporary = False
 
     def _populate_from_rasterio_object(self, read_image):
-        with self._raster_opener(self._filename) as raster:  # type: rasterio.DatasetReader
+        with self._raster_opener(self.source_file) as raster:  # type: rasterio.DatasetReader
             self._dtype = np.dtype(raster.dtypes[0])
 
             if self._affine is None:

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -761,15 +761,6 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             folder = os.path.abspath(os.path.join(filename, os.pardir))
             os.makedirs(folder, exist_ok=True)
 
-        if (
-            (self._image is None and self._filename is not None) and
-            (tags is None and not kwargs)
-        ):
-            rasterio.shutil.copy(self._filename, filename)
-            self._cleanup()
-            self._filename = filename
-            return
-
         internal_mask = kwargs.get('GDAL_TIFF_INTERNAL_MASK', True)
         nodata_value = kwargs.get('nodata', None)
         compression = kwargs.get('compression', Compression.lzw)

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -701,6 +701,16 @@ def test_save_temporary():
         assert not os.path.isfile(src.name)
 
 
+def test_save_uses_copy():
+    band_names = ["b1", "b2", "b3"]
+    raster = GeoRaster2.open("tests/data/raster/rgb.tif", band_names=band_names)
+    with NamedTemporaryFile(suffix='.tif') as target:
+        factors = [2, 4]
+        raster.save(target.name, overviews=True, factors=factors)
+        assert raster.band_names == band_names
+        assert raster.overviews_factors == factors
+
+
 def test_reproject_lazy():
     raster = GeoRaster2.open("tests/data/raster/rgb.tif")
     reprojected = raster.reproject(dst_crs=WGS84_CRS)


### PR DESCRIPTION
Until this PR, 

```python 
rasterio.copy
```

was called only when the save was called without any arguments, so for example if you ran the following code:

```python
r = GeoRaster.open(path)
r.save(tiled=True)
```
we failed 

In this PR I fix this issue, allowing the save to work as much as I can simialr to when the raster was created in memory and from file

I also added a new property called `source_file` this propery is used to read/write are raster instead of `_filename` so `_filename` could be treated as a placeholder

So if someone wants to create a file in azure for example he could run the code that creates a blob url in the `source_file` property 