### PR TITLE
Fix bug in reproject

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1359,6 +1359,13 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         ---------
         out: GeoRaster2
         """
+
+        if not self.not_loaded():
+            with MemoryFile(ext=".tif") as tmp_file:
+                tmp_raster = self.save(tmp_file.name)
+                return tmp_raster.reproject(dst_crs, resolution, dimensions, src_bounds, dst_bounds,
+                                            target_aligned_pixels, resampling, creation_options, **kwargs)
+
         if self._image is None and self._filename is not None:
             # image is not loaded yet
             with tempfile.NamedTemporaryFile(suffix='.tif', delete=False) as tf:

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1301,8 +1301,6 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             ret_val = np.finfo(dtype).max
         return ret_val
 
-
-
     def _reproject(self, new_width, new_height, dest_affine, dtype=None,
                    dst_crs=None, resampling=Resampling.cubic):
         """Return re-projected raster to new raster.
@@ -2140,6 +2138,7 @@ class Histogram:
 
 
 class GeoMultiRaster(GeoRaster2):
+
     def __init__(self, rasters):
         if not rasters:
             raise GeoRaster2Error("GeoMultiRaster does not supports empty rasters list")

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1369,7 +1369,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                      dimensions=dimensions, creation_options=creation_options,
                      src_bounds=src_bounds, dst_bounds=dst_bounds,
                      target_aligned_pixels=target_aligned_pixels,
-                     resampling=resampling, src_nodata=self.nodata_value, **kwargs)
+                     resampling=resampling, **kwargs)
 
             new_raster = self.__class__(filename=tf.name, temporary=True,
                                         band_names=self.band_names)

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -847,7 +847,6 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             os.makedirs(folder, exist_ok=True)
 
         internal_mask = kwargs.get('GDAL_TIFF_INTERNAL_MASK', True)
-        # nodata_value = kwargs.get('nodata', self.nodata_value)
         nodata_value = kwargs.get('nodata', None)
         compression = kwargs.get('compression', Compression.lzw)
         rasterio_envs = {'GDAL_TIFF_INTERNAL_MASK': internal_mask}

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1800,7 +1800,6 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
             filename = self._raster_backed_by_a_file()._filename
             with self._raster_opener(filename) as raster:  # type: rasterio.io.DatasetReader
                 read_params["masked"] = self._read_with_mask(raster, masked)
-                read_params["masked"] = True
                 array = raster.read(bands, **read_params)
             affine = affine or self._calculate_new_affine(window, out_shape[2], out_shape[1])
             raster = self.copy_with(image=array, affine=affine)

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -129,7 +129,6 @@ def merge_all(rasters, roi=None, dest_resolution=None, merge_strategy=MergeStrat
     # Create a list of single band rasters
     all_band_names, projected_rasters = _prepare_rasters(rasters, merge_strategy, empty,
                                                          resampling=resampling)
-
     assert len(projected_rasters) == len(rasters)
 
     prepared_rasters = _apply_pixel_strategy(projected_rasters, pixel_strategy)
@@ -1202,7 +1201,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
 
     def copy_with(self, mutable=False, **kwargs):
         """Get a copy of this GeoRaster with some attributes changed. NOTE: image is shallow-copied!"""
-        init_args = {'affine': self.affine, 'crs': self.crs, 'band_names': self.band_names, "nodata": self.nodata_value}
+        init_args = {'affine': self.affine, 'crs': self.crs, 'band_names': self.band_names, 'nodata': self.nodata_value}
         init_args.update(kwargs)
 
         # The image is a special case because we don't want to make a copy of a possibly big array
@@ -1344,6 +1343,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             band_images.append(dest_image)
         dest_image = np.ma.concatenate(band_images)
         new_raster = self.copy_with(image=dest_image, affine=dst_transform, crs=dst_crs)
+
         return new_raster
 
     def reproject(self, dst_crs=None, resolution=None, dimensions=None,
@@ -1378,7 +1378,6 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         ---------
         out: GeoRaster2
         """
-
         if self._image is None and self._filename is not None:
             # image is not loaded yet
             with tempfile.NamedTemporaryFile(suffix='.tif', delete=False) as tf:

--- a/tests/common_for_tests.py
+++ b/tests/common_for_tests.py
@@ -6,13 +6,14 @@ from telluric.constants import WEB_MERCATOR_CRS
 
 
 def make_test_raster(value=0, band_names=[], height=3, width=4, dtype=np.uint16,
-                     crs=WEB_MERCATOR_CRS, affine=None):
+                     crs=WEB_MERCATOR_CRS, affine=None, image=None):
     if affine is None:
         affine = Affine.translation(10, 12) * Affine.scale(1, -1)
-    shape = [len(band_names), height, width]
-    array = np.full(shape, value, dtype=dtype)
-    mask = np.full(shape, False, dtype=np.bool)
-    image = np.ma.array(data=array, mask=mask)
+    if image is None:
+        shape = [len(band_names), height, width]
+        array = np.full(shape, value, dtype=dtype)
+        mask = np.full(shape, False, dtype=np.bool)
+        image = np.ma.array(data=array, mask=mask)
     raster = tl.GeoRaster2(image=image, affine=affine, crs=crs, band_names=band_names)
     return raster
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -730,6 +730,21 @@ def test_reproject_lazy():
     assert reprojected._temporary
 
 
+def test_reproject_when_having_no_data_values_in_image():
+    shape = (1, 500, 500)
+    arr = np.ones(shape, dtype=np.float32)
+    for i in range(500):
+        for j in range(500):
+            if j % 2 == 0:
+                arr[0,  i, j] = 300
+    arr = np.ma.masked_array(arr, arr == 1)
+    raster = make_test_raster(image=arr)
+    reprojected_raster = raster.reproject(WGS84_CRS, resampling=Resampling.average)
+    counts = np.unique(reprojected_raster.image, return_counts=True)
+    assert counts[0] == 300
+    assert len(counts) == 2
+
+
 def test_georaster_save_unity_affine_emits_warning(recwarn):
     shape = (1, 500, 500)
     arr = np.ones(shape)


### PR DESCRIPTION
We found a bug in reproject that doesn't consider the mask when reprojecting.

And that the no-data was 0 even if the raster had a different value 
 