### PR TITLE
Iterate only over BaseCollection objects

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1683,8 +1683,8 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
         :param mask_shape_nodata: if True - pixels inside shape are set nodata, if False - outside shape is nodata
         :return: GeoRaster2
         """
-        # shape = vector.reproject(self.crs).shape
-        if isinstance(vector, Iterable):
+        from telluric.collections import BaseCollection
+        if isinstance(vector, BaseCollection):
             shapes = [self.to_raster(feature) for feature in vector]
         else:
             shapes = [self.to_raster(vector)]

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -16,6 +16,7 @@ from rasterio.windows import Window
 from telluric.constants import WGS84_CRS, WEB_MERCATOR_CRS
 from telluric.georaster import GeoRaster2, GeoRaster2Error, GeoRaster2Warning, join, MutableGeoRaster
 from telluric.vectors import GeoVector
+from telluric.features import GeoFeature
 
 from common_for_tests import make_test_raster
 
@@ -413,6 +414,12 @@ def test_mask():
     vector = raster.to_world(left_quadrant, dst_crs=raster.crs)
 
     masked = raster.mask(vector)
+    assert not masked.image[:, :w, :h].mask.any()
+    assert masked.image[:, w:, h:].mask.all()
+
+    # masking by GeoFeature
+    feature = GeoFeature(vector, properties={'prop1': 1, 'prop2': 2})
+    masked = raster.mask(feature)
     assert not masked.image[:, :w, :h].mask.any()
     assert masked.image[:, w:, h:].mask.all()
 


### PR DESCRIPTION
This PR solves the following issue:

```
>>> from telluric import GeoFeature, GeoRaster2
>>> from shapely.geometry import Point
>>> r = GeoRaster2.open('tests/data/raster/rgb.tif')
>>> f = GeoFeature(Point(1, 1), {'key': 'value'})
>>> r.mask(f)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/denis/satellogic/telluric/telluric/georaster.py", line 1688, in mask
    shapes = [self.to_raster(feature) for feature in vector]
  File "/home/denis/satellogic/telluric/telluric/georaster.py", line 1688, in <listcomp>
    shapes = [self.to_raster(feature) for feature in vector]
  File "/home/denis/satellogic/telluric/telluric/georaster.py", line 1591, in to_raster
    return transform(vector.get_shape(vector.crs), vector.crs, self.crs, dst_affine=~self.affine)
AttributeError: 'str' object has no attribute 'get_shape'
```