### PR TITLE
Rasterio 1.0.18

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'ipyleaflet!=0.8.2',
         'pyproj',
         'shapely>=1.6.3,<2.*',
-        'rasterio==1.0.13',
+        'rasterio>=1.0.18,<2.*',
         'pillow',
         'mercantile>=0.10.0',
         'matplotlib',

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -689,9 +689,6 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             if self._crs is None:
                 self._crs = copy(raster.crs)
 
-            with rasterio.Env():
-                assert self._crs.is_valid
-
             # if band_names not provided, try read them from raster tags.
             # if not - leave empty, for default:
             key_name = None

--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -276,15 +276,12 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
         crs : ~rasterio.crs.CRS (optional)
             Coordinate Reference System, default to :py:data:`telluric.constants.DEFAULT_CRS`.
         safe: bool, optional
-            Check method arguments validity (only CRS so far) if False,
+            Check method arguments validity (does nothing so far) if False,
             default to True
 
         """
         self._shape = shape  # type: shapely.geometry.base.BaseGeometry
         self._crs = CRS(crs)
-
-        if not safe:
-            assert self._crs.is_valid
 
     @classmethod
     def from_geojson(cls, filename):

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -35,21 +35,11 @@ def test_geovector_has_given_crs():
     assert gv.crs == crs
 
 
-def test_geovector_respects_safe():
-    crs = CRS(init='EPSG:432600')
-
-    # no errors
-    gv = GeoVector(None, crs=crs)
-
-    with pytest.raises(CRSError):
-        GeoVector(None, crs=crs, safe=False)
-
-
 def test_geovector_representation():
     shape = Point(0.0, 0.0)
     gv = GeoVector(shape)
 
-    assert str(gv) == "GeoVector(shape=POINT (0 0), crs=+init=epsg:4326 +no_defs)"
+    assert str(gv) == "GeoVector(shape=POINT (0 0), crs=EPSG:4326)"
 
 
 def test_geovector_from_bounds_has_proper_shape():


### PR DESCRIPTION
is_valid is left useless by design and by convenience (see https://github.com/mapbox/rasterio/issues/1622).