### PR TITLE
Add GeoVector.from_record()

### DIFF
--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -431,6 +431,14 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
             data['coordinates'] = (data['coordinates'],)
         return data
 
+    @classmethod
+    def from_record(cls, record, crs):
+        """Load vector from record."""
+        if 'type' not in record:
+            raise TypeError("The record doesn't contain a valid record.")
+
+        return cls(to_shape(record), crs)
+
     def get_shape(self, crs):
         """Gets the underlying Shapely shape in a specified CRS.
 

--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -435,7 +435,7 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
     def from_record(cls, record, crs):
         """Load vector from record."""
         if 'type' not in record:
-            raise TypeError("The record doesn't contain a valid record.")
+            raise TypeError("The data isn't a valid record.")
 
         return cls(to_shape(record), crs)
 

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -85,6 +85,16 @@ def test_geovector_to_from_geojson():
         assert GeoVector.from_geojson(fp.name) == gv
 
 
+def test_geovector_record_transformation():
+    gv = GeoVector.from_geojson("tests/data/vector/simple_vector.json")
+
+    record = gv.to_record(WGS84_CRS)
+
+    gv_deserialized = GeoVector.from_record(record, WGS84_CRS)
+
+    assert gv == gv_deserialized
+
+
 def test_geovector_from_xyz():
     gv = GeoVector.from_xyz(0, 0, 0)
 


### PR DESCRIPTION
Ability to load a GeoVector that was serialized as record.

Side note: the latest release of PyZMQ at the moment of this PR (pyzmq 18.0.0) is broken and won't install if you try to run the `make build` step from telluric. It has already been fixed in pyzmq's repo, but not yet released. You can prevent the issue by modifying telluric's setup.py before building: add "pyzmq==17.1.3" to the requirements. I don't recommend permanently adding this change to the repo, as it will surely be fixed in a new release of pyzmq in a few days.