### PR TITLE
Workaround to overcome impossible transformations

### DIFF
--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -219,8 +219,20 @@ class _GeoVectorDelegator:
 
         elif item in GEOM_BINARY_PREDICATES:
             def delegated_predicate(self_, other):
-                return getattr(self_.get_shape(self_.crs), item)(
-                    other.get_shape(self_.crs))
+                relationship = getattr(
+                    self_.get_shape(self_.crs), item
+                )(other.get_shape(self_.crs))
+                if item not in ['intersects']:
+                    return relationship
+                else:
+                    # workaround to overcome issue of impossible transformation
+                    if relationship:
+                        return relationship
+                    else:
+                        relationship = getattr(
+                            self_.get_shape(other.crs), item
+                        )(other.get_shape(other.crs))
+                    return relationship
 
             delegated_predicate.__doc__ = getattr(self._shape, item).__doc__
 

--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -222,17 +222,14 @@ class _GeoVectorDelegator:
                 relationship = getattr(
                     self_.get_shape(self_.crs), item
                 )(other.get_shape(self_.crs))
-                if item not in ['intersects']:
+                # workaround to overcome issue of impossible transformation
+                if relationship:
                     return relationship
                 else:
-                    # workaround to overcome issue of impossible transformation
-                    if relationship:
-                        return relationship
-                    else:
-                        relationship = getattr(
-                            self_.get_shape(other.crs), item
-                        )(other.get_shape(other.crs))
-                    return relationship
+                    relationship = getattr(
+                        self_.get_shape(other.crs), item
+                    )(other.get_shape(other.crs))
+                return relationship
 
             delegated_predicate.__doc__ = getattr(self._shape, item).__doc__
 

--- a/tests/test_geovector.py
+++ b/tests/test_geovector.py
@@ -288,6 +288,14 @@ def test_delegated_binary_predicates(predicate_name):
             getattr(vector_1.get_shape(vector_1.crs), predicate_name)(vector_2.get_shape(vector_2.crs)))
 
 
+@pytest.mark.parametrize("predicate_name", ["intersects"])
+def test_delegated_binary_predicates_for_impossible_transformations(predicate_name):
+    vector_1 = GeoVector.from_bounds(-180, -90, 180, 90, crs=CRS(init='epsg:4326'))
+    vector_2 = GeoVector.from_bounds(-1000, -1000, 1000, 1000, crs=CRS(init='epsg:3857'))
+
+    assert getattr(vector_2, predicate_name)(vector_1)
+
+
 @pytest.mark.parametrize("operation_name", GEOM_BINARY_OPERATIONS)
 def test_delegated_operations(operation_name):
     vector_1 = GeoVector(Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]))


### PR DESCRIPTION
This PR solves the following issue:

```
>>> from rasterio.crs import CRS
>>> from telluric import GeoVector
>>> vector_1 = GeoVector.from_bounds(-180, -90, 180, 90, crs=CRS(init='epsg:4326')) 
>>> vector_2 = GeoVector.from_bounds(0, 0, 1000, 1000, crs=CRS(init='epsg:3857'))
>>> vector_2.intersects(vector_1) 
False 
```