### PR TITLE
Running mypy with Python 3.4 or lower is not supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   - python: "nightly"
 
 before_install:
-  - pip install pycodestyle mypy
+  - pip install pycodestyle mypy==0.670 # See https://github.com/python/mypy/issues/6564
   - pycodestyle . --count
   - mypy --ignore-missing-imports --check-untyped-defs telluric/
 


### PR DESCRIPTION
Pin mypy version to the previous one.