### PR TITLE
Creating cog with internal mask

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -852,7 +852,6 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                                           mask_band=0)
             agg.save(destination_file)
 
-
     def save(self, filename, tags=None, **kwargs):
         """
         Save GeoRaster to a file.

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -845,11 +845,12 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         """
         with tempfile.TemporaryDirectory() as directory:
             for raster, offsets in self.chunks(shape=chunk_size):
-                raster.save("%s/%s_%s.tif" % (directory, offsets[0], offsets[1]))
-        agg = GeoRaster2.from_rasters([GeoRaster2.open(rc) for rc in glob.glob("%s/*" % directory)],
-                                      destination_file="%s/vrt.vrt" % (directory),
-                                      mask_band=0)
-        agg.save(destination_file)
+                filename = "%s/%s_%s.tif" % (directory, offsets[0], offsets[1])
+                raster.save(filename)
+            agg = GeoRaster2.from_rasters([GeoRaster2.open(rc) for rc in glob.glob("%s/*.tif" % directory)],
+                                          destination_file="%s/vrt.vrt" % (directory),
+                                          mask_band=0)
+            agg.save(destination_file)
 
 
     def save(self, filename, tags=None, **kwargs):

--- a/telluric/vrt.py
+++ b/telluric/vrt.py
@@ -226,7 +226,7 @@ def raster_collection_vrt(fc, relative_to_vrt=True, nodata=None, mask_band=None)
 
     last_band_idx = 0
     if mask_band is not None:
-        mask_band = vrt.add_mask_band("Byte")
+        mask_band_elem = vrt.add_mask_band("Byte")
 
     for raster in rasters:
         for i, band_name in enumerate(raster.band_names):
@@ -253,7 +253,7 @@ def raster_collection_vrt(fc, relative_to_vrt=True, nodata=None, mask_band=None)
                                       raster.block_shape(i)[1], raster.block_shape(i)[0],
                                       src_window, dst_window)
             if i == mask_band:
-                vrt.add_band_simplesource(mask_band, "mask,%s" % (mask_band + 1), "Byte", relative_to_vrt, file_name,
+                vrt.add_band_simplesource(mask_band_elem, "mask,%s" % (mask_band + 1), "Byte", relative_to_vrt, file_name,
                                           raster.width, raster.height,
                                           raster.block_shape(i)[1], raster.block_shape(i)[0],
                                           src_window, dst_window)

--- a/telluric/vrt.py
+++ b/telluric/vrt.py
@@ -253,7 +253,10 @@ def raster_collection_vrt(fc, relative_to_vrt=True, nodata=None, mask_band=None)
                                       raster.block_shape(i)[1], raster.block_shape(i)[0],
                                       src_window, dst_window)
             if i == mask_band:
-                vrt.add_band_simplesource(mask_band_elem, "mask,%s" % (mask_band + 1), "Byte", relative_to_vrt, file_name,
+                vrt.add_band_simplesource(mask_band_elem, "mask,%s" % (mask_band + 1),
+                                          "Byte",
+                                          relative_to_vrt,
+                                          file_name,
                                           raster.width, raster.height,
                                           raster.block_shape(i)[1], raster.block_shape(i)[0],
                                           src_window, dst_window)


### PR DESCRIPTION
When using a cog with `get_window` and `get_tile` implemented in telluric project, when the original raster has no internal mask but `nodata` value then the `get_window` fetches much more data than needed

in order to solve that, I suggest that when saving with `masked=True` which is the default we should covert the nodata to internal mask

these works well when the raster is loaded into memory but deosn't work when the raster is located on disk, so I implemented this behavior by reading the original raster chunk by chunk and converting each chunk to internal mask, and then merging the chunks back to a single raster