### PR TITLE
Remove unnecessary fiona.Env

### DIFF
--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -469,12 +469,11 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
         return self._shape._repr_svg_()
 
     def reproject(self, new_crs):
-        with fiona.Env():
-            if new_crs == self.crs:
-                return self
-            else:
-                new_shape = transform(self._shape, self._crs, new_crs)
-                return self.__class__(new_shape, new_crs)
+        if new_crs == self.crs:
+            return self
+        else:
+            new_shape = transform(self._shape, self._crs, new_crs)
+            return self.__class__(new_shape, new_crs)
 
     def rasterize(self, dest_resolution, *, fill_value=None, bounds=None, dtype=None, crs=None, **kwargs):
         # Import here to avoid circular imports


### PR DESCRIPTION
It turns out that `fiona.Env.__enter__` is _extremely slow_ and has an extreme performance penalty when calling `GeoVector.reproject` in a loop. After removing this line, the running time of our script when from 2.5 minutes to 1 minute.

It was introduced in https://github.com/satellogic/telluric/commit/34ec32f48ec510dbcb8ce5991820e180890933ab without much explanation. Locally all tests passed, so I think it should be safe to merge, but we have had problems with this in the past so please check it. In any case, it would be very important for us to remove that line there, if possible.