### PR TITLE
GeoRaster2.save_cloud_optimized: Remove unused var

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1811,8 +1811,6 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
         src = self  # GeoRaster2.open(self._filename)
 
         with tempfile.NamedTemporaryFile(suffix='.tif') as tf:
-            with self._raster_opener(self.source_file) as r:
-                nodata = r.nodata
             src.save(tf.name, overviews=False)
             convert_to_cog(tf.name, dest_url, resampling, blocksize, overview_blocksize, creation_options)
 

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1808,10 +1808,8 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
 
         """
 
-        src = self  # GeoRaster2.open(self._filename)
-
         with tempfile.NamedTemporaryFile(suffix='.tif') as tf:
-            src.save(tf.name, overviews=False)
+            self.save(tf.name, overviews=False)
             convert_to_cog(tf.name, dest_url, resampling, blocksize, overview_blocksize, creation_options)
 
         geotiff = GeoRaster2.open(dest_url)


### PR DESCRIPTION
`_raster_opener` can leak memory, since it never closes the object.