### PR TITLE
Make optional matplotlib ipyleaflet and folium dependencies

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install pycodestyle pytest
         python -m pip install --prefer-binary .  # Test installation correctness
-        python -m pip install .[dev]  # Test development dependencies
+        python -m pip install .[dev,vis]  # Test extra dependencies
     - name: Lint with pycodestyle and mypy
       run: |
         pycodestyle . --count

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ celerybeat-schedule
 static
 venv
 .tags
+*sublime*
 
 # Jupyter notebooks
 .ipynb_checkpoints

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 WORKDIR /usr/src
 COPY . /usr/src
 
-RUN pip3 install --editable .[dev]
+RUN pip3 install --editable .[dev] .[vis]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ RUN cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
 WORKDIR /usr/src
 COPY . /usr/src
 
-RUN pip3 install --editable .[dev] .[vis]
+RUN pip3 install --editable .[dev,vis]

--- a/setup.py
+++ b/setup.py
@@ -22,15 +22,12 @@ setup(
         'affine',
         'dsnparse',
         'fiona>=1.8.4,<2.*',
-        'folium>=0.6.0',
-        'ipyleaflet!=0.8.2',
         'pyproj<2; python_version<="3.4"',
         'pyproj<3; python_version>="3.5"',
         'shapely>=1.6.3,<2.*',
         'rasterio>=1.0.21,<2.*',
         'pillow',
         'mercantile>=0.10.0',
-        'matplotlib',
         'boltons',
         'imageio',
         "lxml"
@@ -48,6 +45,11 @@ setup(
             'nbsphinx',
             'sphinx_rtd_theme'
         ],
+        'vis': [
+            'ipyleaflet!=0.8.2',
+            'matplotlib',
+            'folium>=0.6.0',
+        ]
     },
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Closes #260 

To relieve other projects using telluric with no visualizations purposes, we make optional these:

- matplotlib
- ipyleaflet
- folium 

In addition, temporarily restrict pyproj to <3.
New 3 version doesn't support python < 6 anymore.