### PR TITLE
Set _dtype attribute in image setter for MutableGeoRaster

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -2159,6 +2159,7 @@ class MutableGeoRaster(GeoRaster2):
         if band_names is not None:
             self._set_bandnames(band_names)
         self._set_shape(image.shape)
+        self._dtype = np.dtype(image.dtype)
 
     @property
     def band_names(self):

--- a/tests/test_georaster_mutable.py
+++ b/tests/test_georaster_mutable.py
@@ -130,3 +130,9 @@ def test_set_affine_immutable():
 def test_reporject_of_mutable():
     raster = GeoRaster2.open("tests/data/raster/overlap2.tif", mutable=True).reproject(dst_crs=WGS84_CRS)
     assert isinstance(raster, MutableGeoRaster)
+
+
+def test_image_setter_dtype():
+    raster = GeoRaster2.open("tests/data/raster/overlap2.tif", mutable=True)
+    raster.image = raster.image.astype('uint16')
+    assert raster.dtype == raster.image.dtype


### PR DESCRIPTION
This PR fixes a bug that appears when setting a new `image` attribute for a `MutableGeoRaster`. The `dtype` property doesn't get updated and it can lead to an inconsistency between the array real type and the public property.
closes #287 
