### PR TITLE
Set crs as empty rasterio.crs.CRS() instance instead of None when image file has no crs

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -608,7 +608,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         """
         super().__init__(image=image, band_names=band_names, shape=shape, nodata=nodata)
         self._affine = deepcopy(affine)
-        self._crs = CRS(copy(crs)) if crs else None  # type: Union[None, CRS]
+        self._crs = None if crs is None else CRS(crs)  # type: Union[None, CRS]
         self._filename = filename
         self._temporary = temporary
         self._footprint = copy(footprint)
@@ -714,7 +714,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                 self._affine = copy(raster.transform)
 
             if self._crs is None:
-                self._crs = copy(raster.crs)
+                self._crs = CRS() if raster.crs is None else copy(raster.crs)
 
             # if band_names not provided, try read them from raster tags.
             # if not - leave empty, for default:

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -975,6 +975,7 @@ def test_from_assets_to_assets():
 def test_empty_crs():
     raster = GeoRaster2.open("tests/data/raster/no_georef.png")
     assert raster.crs == CRS()
+    assert raster.crs.is_valid is False
 
 
 def test_copy_raster_without_crs():

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -970,3 +970,14 @@ def test_blockshapes_for_file_raster():
 def test_from_assets_to_assets():
     raster = GeoRaster2.open("tests/data/raster/rgb.tif")
     assert raster == GeoRaster2.from_assets(raster.to_assets())
+
+
+def test_empty_crs():
+    raster = GeoRaster2.open("tests/data/raster/no_georef.png")
+    assert raster.crs == CRS()
+
+
+def test_copy_raster_without_crs():
+    raster = GeoRaster2.open("tests/data/raster/no_georef.png")
+    raster_copy = raster.copy_with()
+    assert raster_copy.crs == CRS()


### PR DESCRIPTION
closes #291 