### PR TITLE
Make GeoRaster2.resize faster

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1302,6 +1302,15 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
 
         :return: GeoRaster2
         """
+        if resampling in [
+            Resampling.min,
+            Resampling.max,
+            Resampling.med,
+            Resampling.q1,
+            Resampling.q3,
+        ]:
+            raise GeoRaster2Error("Resampling {!r} can't be used for resize".format(resampling))
+
         # validate input:
         if sum([ratio is not None, ratio_x is not None and ratio_y is not None,
                 dest_height is not None or dest_width is not None, dest_resolution is not None]) != 1:
@@ -1326,13 +1335,18 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         """Return raster resized by ratio."""
         new_width = int(np.ceil(self.width * ratio_x))
         new_height = int(np.ceil(self.height * ratio_y))
-
         dest_affine = self.affine * Affine.scale(1 / ratio_x, 1 / ratio_y)
-        if self.not_loaded():
-            window = rasterio.windows.Window(0, 0, self.width, self.height)
-            resized_raster = self.get_window(window, xsize=new_width, ysize=new_height, resampling=resampling)
-        else:
-            resized_raster = self._reproject(new_width, new_height, dest_affine, resampling=resampling)
+
+        raster = self._raster_backed_by_a_file()
+        window = rasterio.windows.Window(0, 0, self.width, self.height)
+        resized_raster = raster.get_window(
+            window=window,
+            xsize=new_width,
+            ysize=new_height,
+            resampling=resampling,
+            affine=dest_affine,
+        )
+
         return resized_raster
 
     def to_pillow_image(self, return_mask=False):

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -186,7 +186,7 @@ def test_resize(raster):
     for resampling_name in resampling_modes:
         resampling = Resampling[resampling_name]
         print('\nresampling name:', resampling_name)
-        if resampling_name == 'gauss':
+        if resampling_name in ['min', 'max', 'med', 'q1', 'q3']:
             print('\nskipping', resampling_name)
             continue
         if resampling_name not in ['bilinear', 'cubic', 'cubic_spline', 'lanczos', 'gauss']:


### PR DESCRIPTION
Before (in-memory raster):

```python
In [1]: import telluric as tl

In [2]: r = tl.GeoRaster2.open("creaf_gmap.tif", lazy_load=False)

In [3]: %time r.resize(ratio=0.5)
CPU times: user 3.38 s, sys: 23 ms, total: 3.4 s
Wall time: 3.4 s
```
Before (on-disk raster):

```python
In [1]: import telluric as tl

In [2]: r = tl.GeoRaster2.open("creaf_gmap.tif", lazy_load=True)

In [3]: %time r.resize(ratio=0.5)
CPU times: user 193 ms, sys: 346 µs, total: 193 ms
Wall time: 193 ms
```

After (in-memory raster):

```python
In [1]: import telluric as tl

In [2]: r = tl.GeoRaster2.open("creaf_gmap.tif", lazy_load=False)

In [3]: %time r.resize(ratio=0.5)  # 50x faster
CPU times: user 58.1 ms, sys: 8.62 ms, total: 66.7 ms
Wall time: 65.8 ms
```

After (on-disk raster):

```python
In [1]: import telluric as tl

In [2]: r = tl.GeoRaster2.open("creaf_gmap.tif", lazy_load=True)

In [3]: %time r.resize(ratio=0.5)  # 2.5x faster
CPU times: user 64.9 ms, sys: 11.1 ms, total: 75.9 ms
Wall time: 75.2 ms
```