### PR TITLE
Make MutableGeoraster implement limit_to_bands()

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -2244,6 +2244,17 @@ class MutableGeoRaster(GeoRaster2):
     def _raster_backed_by_a_file(self):
         return self._as_in_memory_geotiff()
 
+    def limit_to_bands(self, bands):
+        if self._image is not None:
+            bands_data = self.bands_data(bands)
+            return self.copy_with(image=bands_data, band_names=bands, mutable=True)
+        else:
+            indices = self.bands_indices(bands)
+            bidxs = map(lambda idx: idx + 1, indices)
+            doc = boundless_vrt_doc(self._raster_opener(self.source_file), bands=bidxs)
+            filename = self._save_to_destination_file(doc.tostring())
+            return self.__class__(filename=filename, band_names=bands)
+
 
 class Histogram:
 

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -256,6 +256,13 @@ def test_limit_to_bands_off_memory():
     assert r2._image is None
 
 
+def test_limit_to_bands_mutable():
+    mutable_lazy = GeoRaster2.open("tests/data/raster/rgb.tif", lazy_load=True, mutable=True)
+    mutable_loaded = GeoRaster2.open("tests/data/raster/rgb.tif", lazy_load=False, mutable=True)
+    assert isinstance(mutable_lazy, MutableGeoRaster)
+    assert isinstance(mutable_loaded, MutableGeoRaster)
+
+
 def test_to_png():
     for raster in [some_raster, some_raster_multiband]:
         png_bytes = raster.to_png(transparent=True, thumbnail_size=512)


### PR DESCRIPTION
The `GeoRaster2.limit_to_bands` method behaves differently depending on whether `_image` has been already read or not:
```
    def limit_to_bands(self, bands):
        if self._image is not None:
            bands_data = self.bands_data(bands)
            return self.copy_with(image=bands_data, band_names=bands)
        else:
            indices = self.bands_indices(bands)
            bidxs = map(lambda idx: idx + 1, indices)
            doc = boundless_vrt_doc(self._raster_opener(self.source_file), bands=bidxs)
            filename = self._save_to_destination_file(doc.tostring())
            return self.__class__(filename=filename, band_names=bands)
```           

When dealing with a `MutableGeoraster` instance this provokes that depending on this condition the returned type is `MutableGeoRaster` or `GeoRaster2`:
```
In [2]: img = GeoRaster2.open("whatever.tif", lazy_load=False, mutable=True)

In [5]: band = img.limit_to_bands(["raw"])

In [6]: type(band)
Out[6]: telluric.georaster.GeoRaster2

In [7]: img = GeoRaster2.open("whatever.tif", mutable=True)

In [8]: band = img.limit_to_bands(["raw"])

In [9]: type(band)
Out[9]: telluric.georaster.MutableGeoRaster
```
I made `MutableGeoRaster` implement the `limit_to_bands` method. This could also be accomplished modifying the base method but I don't know if `Georaster2` class should know about its childs. What do you think?