### PR TITLE
Add another filter for corner case in merge_all

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -251,7 +251,10 @@ def _prepare_rasters(
     all_band_names = IndexedSet(first.band_names)
     projected_rasters = []
     for raster in rasters:
-        projected_raster = _prepare_other_raster(first, raster, resampling=resampling, crop=crop)
+        try:
+            projected_raster = _prepare_other_raster(first, raster, resampling=resampling, crop=crop)
+        except ValueError:
+            projected_raster = None
 
         # Modify the bands only if an intersecting raster was returned
         if projected_raster:

--- a/tests/test_merge_all.py
+++ b/tests/test_merge_all.py
@@ -553,4 +553,5 @@ def test_rasters_close_than_resolution_to_roi_2():
     one = make_test_raster(1, [1], height=4696, width=4696, affine=one_affine, crs=CRS.from_epsg(32641))
     other = make_test_raster(2, [1], height=2616, width=5402, affine=other_affine, crs=CRS.from_epsg(32641))
     roi = GeoVector.from_bounds(598847.0000000002, 3466365.999999999, 603542.9999999995, 3471062, crs=one.crs)
-    _ = merge_all([one, other], dest_resolution=(1, 1), roi=roi)
+    merged = merge_all([one, other], dest_resolution=(1, 1), roi=roi)
+    assert merged == one

--- a/tests/test_merge_all.py
+++ b/tests/test_merge_all.py
@@ -540,3 +540,17 @@ def test_raster_closer_than_resolution_to_roi():
         dest_resolution=(1, 1),
         merge_strategy=MergeStrategy.INTERSECTION,
     )
+
+
+def test_rasters_close_than_resolution_to_roi_2():
+    one_affine = Affine(1, 0, 598847, 0, -1, 3471062)
+    other_affine = Affine(0.9998121393135052104028,
+                          -0.000563382202975665213,
+                          596893.24732190347276628,
+                          -0.000249934917683214408,
+                          -1.000473374252140335016,
+                          3466367.0648421039804816)
+    one = make_test_raster(1, [1], height=4696, width=4696, affine=one_affine, crs=CRS.from_epsg(32641))
+    other = make_test_raster(2, [1], height=2616, width=5402, affine=other_affine, crs=CRS.from_epsg(32641))
+    roi = GeoVector.from_bounds(598847.0000000002, 3466365.999999999, 603542.9999999995, 3471062, crs=one.crs)
+    _ = merge_all([one, other], dest_resolution=(1,1), roi=roi)

--- a/tests/test_merge_all.py
+++ b/tests/test_merge_all.py
@@ -553,4 +553,4 @@ def test_rasters_close_than_resolution_to_roi_2():
     one = make_test_raster(1, [1], height=4696, width=4696, affine=one_affine, crs=CRS.from_epsg(32641))
     other = make_test_raster(2, [1], height=2616, width=5402, affine=other_affine, crs=CRS.from_epsg(32641))
     roi = GeoVector.from_bounds(598847.0000000002, 3466365.999999999, 603542.9999999995, 3471062, crs=one.crs)
-    _ = merge_all([one, other], dest_resolution=(1,1), roi=roi)
+    _ = merge_all([one, other], dest_resolution=(1, 1), roi=roi)


### PR DESCRIPTION
There is another merged PR that focused on this same issue https://github.com/satellogic/telluric/pull/296 but it was discovered then that the very same thing can raise another problem and it is not covered by that fix.

When trying to merge some images using `telluric.georaster.merge_all`, if a pair of them are really close (around images resolution) it appears that their footprints intersect but if you try to crop those images an exception is raised stating that a negative width/height can't be used. This PR just adds a catch for `ValueError` to avoid that problem and let other images to merge, if they can.