### PR TITLE
Fix GeoRaster2.save method

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pycodestyle pytest
         python -m pip install --prefer-binary .[dev]  # Test installation correctness
         if [ -n "$EXTRA_DEPS" ]; then python -m pip install ".[$EXTRA_DEPS]"; fi
       env:

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,8 @@ setup(
         'dev': [
             'coverage',
             'mypy',
+            'types-python-dateutil',
+            'types-pkg_resources',
             'packaging',
             'pycodestyle',
             'pytest>=4',

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -980,7 +980,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                     if params.get('masked') and nodata_mask:
                         self._convert_to_internal_mask(filename)
                     else:
-                        rasterio.shutil.copy(self.source_file, filename, creation_options=creation_options)
+                        rasterio.shutil.copy(self.source_file, filename, **creation_options)
                     self._cleanup()
                     with GeoRaster2._raster_opener(filename, "r+",) as r:
                         self._add_overviews_and_tags(r, tags, kwargs)


### PR DESCRIPTION
`creation_options` argument of [rasterio.shutil.copy](https://rasterio.readthedocs.io/en/latest/api/rasterio.shutil.html) is `**kwargs`