### PR TITLE
make copy_with and dependant methods conserve mutability by default

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1269,8 +1269,10 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
 
         return self.copy_with(mutable=mutable)
 
-    def copy_with(self, mutable=False, **kwargs):
+    def copy_with(self, mutable=None, **kwargs):
         """Get a copy of this GeoRaster with some attributes changed. NOTE: image is shallow-copied!"""
+        if mutable is None:
+            mutable = isinstance(self, MutableGeoRaster)
         init_args = {'affine': self.affine, 'crs': self.crs, 'band_names': self.band_names, 'nodata': self.nodata_value}
         init_args.update(kwargs)
 

--- a/tests/test_georaster_mutable.py
+++ b/tests/test_georaster_mutable.py
@@ -136,3 +136,19 @@ def test_image_setter_dtype():
     raster = GeoRaster2.open("tests/data/raster/overlap2.tif", mutable=True)
     raster.image = raster.image.astype('uint16')
     assert raster.dtype == raster.image.dtype
+
+
+def test_conserved_mutability():
+    def _mutable(raster):
+        return isinstance(raster, MutableGeoRaster)
+
+    raster = multi_raster_16b()
+    assert not _mutable(raster)
+    mutable_raster = raster.as_mutable()
+    assert _mutable(mutable_raster)
+
+    for r in [raster, mutable_raster]:
+        copied = r.copy_with()
+        assert _mutable(copied) == _mutable(r)
+        resized = r.resize(1.0)
+        assert _mutable(resized) == _mutable(r)


### PR DESCRIPTION
fixes #304 