### PR TITLE
Use non-zero precision for window calculations

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1167,7 +1167,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         else:
             window = self.window(*bounds)
         if to_round:
-            window = window.round_offsets(pixel_precision=0).round_shape(op='ceil')
+            window = window.round_offsets(pixel_precision=3).round_shape(op='ceil')
         return window
 
     def _vector_to_raster_bounds(self, vector, boundless=False):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -8,7 +8,9 @@ import fiona
 import tempfile
 
 import pytest
+import shapely
 from unittest import mock
+from packaging import version
 
 from shapely.geometry import Polygon, Point, mapping
 
@@ -94,7 +96,10 @@ def test_convex_hull_raises_warning_with_invalid_shape():
     with pytest.warns(UserWarning) as record:
         fcol.convex_hull
 
-    assert len(record) == 1
+    if version.parse(shapely.__version__) < version.parse('1.8.0'):
+        assert len(record) == 1
+    else:
+        assert len(record) == 2
     assert record[0].message.args[0] == "Some invalid shapes found, discarding them."
 
 


### PR DESCRIPTION
Before:
```
In [1]: from rasterio.windows import Window                                                                                                                   

In [2]: w1 = Window(col_off=1337.90059880239, row_off=1626.659092546026, width=100, height=100)                                                               

In [3]: w2 = Window(col_off=1337.5005988023904, row_off=1626.0257592126945, width=100, height=100)                                                            

In [4]: w1 = w1.round_offsets(pixel_precision=0)                                                                                                              

In [5]: w2 = w2.round_offsets(pixel_precision=0)                                                                                                              

In [6]: w1.row_off, w2.row_off                                                                                                                                
Out[6]: (1627, 1626)
```

After:
```
In [7]: w1 = Window(col_off=1337.90059880239, row_off=1626.659092546026, width=100, height=100)                                                               

In [8]: w2 = Window(col_off=1337.5005988023904, row_off=1626.0257592126945, width=100, height=100)                                                            

In [9]: w1 = w1.round_offsets(pixel_precision=3)                                                                                                              

In [10]: w2 = w2.round_offsets(pixel_precision=3)                                                                                                             

In [11]: w1.row_off, w2.row_off                                                                                                                               
Out[11]: (1626, 1626)
```