### PR TITLE
support saving with empty crs and geo

### DIFF
--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -999,16 +999,10 @@ def test_from_assets_to_assets():
     assert raster == GeoRaster2.from_assets(raster.to_assets())
 
 
-def test_empty_crs():
-    raster = GeoRaster2.open("tests/data/raster/no_georef.png")
-    assert raster.crs == CRS()
-    assert raster.crs.is_valid is False
-
-
 def test_copy_raster_without_crs():
     raster = GeoRaster2.open("tests/data/raster/no_georef.png")
     raster_copy = raster.copy_with()
-    assert raster_copy.crs == CRS()
+    assert raster_copy.crs == raster.crs
 
 
 def test_virtual_filesystem_raster():

--- a/tests/test_nongeo.py
+++ b/tests/test_nongeo.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+import numpy as np
+from affine import Affine
+from telluric.constants import DEFAULT_CRS
+from telluric import GeoRaster2
+
+
+def test_save_nongeo(tmp_path):
+    raster = GeoRaster2(image=np.ones([10, 10], dtype=np.uint8),
+                        crs=DEFAULT_CRS, affine=Affine.translation(10, 100))
+    path = tmp_path / 'raster1.tif'
+    raster.save(path)
+    raster = GeoRaster2.open(path)
+    assert raster.crs is not None and raster.affine is not None
+
+    raster = raster.copy_with(crs=None, affine=None)
+    assert raster.crs is None and raster.affine is None
+    path = Path('/tmp/raster2.tif')
+    raster.save(path)
+
+    raster = GeoRaster2.open(path)
+    assert raster.crs is None
+    assert raster.affine == Affine.identity()  # rasterio does this


### PR DESCRIPTION
As first step towards supporting rasters that have RPC (or GCP) information instead of Affine+crs,
I would like to have the following problems solved:

1. The infinite-recursion problem that happens when trying to do certain operations on a raster is missing transform or crs should be solved (it is confusing and unintuitive anyways - if some operation is not supported, it should fail with proper error, rather than "out of memory"

2. If we load a raster that has no transform or crs, we should be able to save it back, keeping all information that we did not touch (e.g. if it had band names, RPC tags, etc. they should be preserved). Currently it crashes due to out-of-memory as in 1
