### PR TITLE
Stop using deprecated method in the tile server

### DIFF
--- a/telluric/util/local_tile_server.py
+++ b/telluric/util/local_tile_server.py
@@ -57,6 +57,8 @@ class TileServerHandler(tornado.web.RequestHandler):
 
             if tile:
                 self.set_header("Content-type", "image/png")
+                if tile.num_bands < 3:
+                    tile = tile.colorize("gray")
                 self.finish(tile.to_png())
             else:
                 self.send_error(404)

--- a/tests/test_local_tile_server.py
+++ b/tests/test_local_tile_server.py
@@ -2,6 +2,7 @@ import pytest
 from unittest import mock
 
 pytest.importorskip("tornado")  # noqa: E402
+pytest.importorskip("matplotlib")  # noqa: E402
 
 from common_for_tests import make_test_raster
 from tornado.testing import AsyncHTTPTestCase


### PR DESCRIPTION
To overcome the following warnings:
```
tests/test_local_tile_server.py::TestFCLocalTileServer::test_raster_collection_merges_data
tests/test_local_tile_server.py::TestRasterLocalTileServer::test_raster_collection_merges_data
  /home/denis/satellogic/telluric/telluric/georaster.py:1554: GeoRaster2Warning: Deprecation: to_png of less then three bands raster will be not be supported in next release, please use: .colorize('gray').to_png()
    release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
```