### PR TITLE
Remove invalid creation options

### DIFF
--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -613,7 +613,7 @@ class _CollectionGroupBy:
                     feature.geometry,
                     {key: feature[key]}
                 )
-                results[name].append(new_feature)
+                results[name].append(new_feature)  # type: ignore
 
         return self.__class__(results)
 

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -1404,7 +1404,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         if np.issubdtype(dtype, np.integer):
             ret_val = np.iinfo(dtype).max
         elif np.issubdtype(dtype, np.floating):
-            ret_val = np.finfo(dtype).max
+            ret_val = np.finfo(dtype).max  # type: ignore
         return ret_val
 
     def _reproject(self, new_width, new_height, dest_affine, dtype=None,

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -75,10 +75,11 @@ def _creation_options_for_cog(creation_options, source_profile, blocksize):
     if not(creation_options):
         creation_options = {}
 
-    creation_options["blocksize"] = blocksize
+    creation_options["blockxsize"] = blocksize
+    creation_options["blockysize"] = blocksize
     creation_options["tiled"] = True
-    defaults = {"nodata": None, "compress": "lzw"}
-    for key in ["nodata", "compress"]:
+    defaults = {"compress": "lzw"}
+    for key in ["compress"]:
         if key not in creation_options:
             creation_options[key] = source_profile.get(key, defaults.get(key))
     return creation_options
@@ -98,7 +99,7 @@ def convert_to_cog(source_file, destination_file, resampling=rasterio.enums.Resa
     """
 
     with rasterio.open(source_file) as src:
-        # creation_options overrides proile
+        # creation_options overrides profile
         source_profile = src.profile
     creation_options = _creation_options_for_cog(creation_options, source_profile, blocksize)
 


### PR DESCRIPTION
There are no such creation options as `NODATA` and `BLOCKSIZE` for GeoTIFF driver.