### PR TITLE
Add rpcs support 

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -936,7 +936,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         """ Get params dict needed for saving the raster"""
         driver = gdal_drivers[extension]
         return {
-            'mode': "w", 'transform': self.affine, 'crs': self.crs,
+            'mode': "w", 'transform': self.affine, 'crs': self.crs, 'rpcs': self.rpcs,
             'driver': driver, 'width': self.shape[2], 'height': self.shape[1], 'count': self.shape[0],
             'dtype': dtype_map[self.dtype.type],
             'nodata': nodata,

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -646,10 +646,12 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                 return RPC.from_gdal(rpcs)
             else:
                 return RPC(height_off=rpcs["HEIGHT_OFF"], height_scale=rpcs["HEIGHT_SCALE"], lat_off=rpcs["LAT_OFF"],
-                           lat_scale=rpcs["LAT_SCALE"], line_den_coeff=rpcs["LINE_DEN_COEFF"], line_num_coeff=rpcs["LINE_NUM_COEFF"],
-                           line_off=rpcs["LINE_OFF"], line_scale=rpcs["LINE_SCALE"], long_off=rpcs["LONG_OFF"], long_scale=rpcs["LONG_SCALE"],
-                           samp_den_coeff=rpcs["SAMP_DEN_COEFF"], samp_num_coeff=rpcs["SAMP_NUM_COEFF"], samp_off=rpcs["SAMP_OFF"],
-                           samp_scale=rpcs["SAMP_SCALE"], err_bias=rpcs.get("ERR_BIAS"), err_rand=rpcs.get("ERR_RAND"))
+                           lat_scale=rpcs["LAT_SCALE"], line_den_coeff=rpcs["LINE_DEN_COEFF"],
+                           line_num_coeff=rpcs["LINE_NUM_COEFF"], line_off=rpcs["LINE_OFF"],
+                           line_scale=rpcs["LINE_SCALE"], long_off=rpcs["LONG_OFF"], long_scale=rpcs["LONG_SCALE"],
+                           samp_den_coeff=rpcs["SAMP_DEN_COEFF"], samp_num_coeff=rpcs["SAMP_NUM_COEFF"],
+                           samp_off=rpcs["SAMP_OFF"], samp_scale=rpcs["SAMP_SCALE"], err_bias=rpcs.get("ERR_BIAS"),
+                           err_rand=rpcs.get("ERR_RAND"))
         else:
             GeoRaster2Error('Wrong input format for rpcs')
 
@@ -1324,7 +1326,8 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         """Get a copy of this GeoRaster with some attributes changed. NOTE: image is shallow-copied!"""
         if mutable is None:
             mutable = isinstance(self, MutableGeoRaster)
-        init_args = {'affine': self.affine, 'crs': self.crs, 'band_names': self.band_names, 'nodata': self.nodata_value}
+        init_args = {'affine': self.affine, 'crs': self.crs, 'band_names': self.band_names,
+                     'nodata': self.nodata_value}
         init_args.update(kwargs)
 
         # The image is a special case because we don't want to make a copy of a possibly big array
@@ -1465,9 +1468,9 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         dst_crs = dst_crs or self.crs
         dtype = dtype or self.image.data.dtype
         max_dtype_value = self._max_per_dtype(self.dtype)
-        if rpcs is not None: # src_transform, and rpcs are mutually exclusive parameters
+        if rpcs is not None:  # src_transform, and rpcs are mutually exclusive parameters
             src_transform = None
-            src_crs = WGS84_CRS # by rpcs definition
+            src_crs = WGS84_CRS  # by rpcs definition
         else:
             src_transform = self._patch_affine(self.affine)
             src_crs = self.crs
@@ -1550,8 +1553,8 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
             # https://docs.python.org/3/library/types.html#types.SimpleNamespace
             if self.crs is not None:
                 src = SimpleNamespace(width=self.width, height=self.height, transform=self.transform, crs=self.crs,
-                                    bounds=BoundingBox(*self.footprint().get_bounds(self.crs)), gcps=None)
-            else: # for rpcs based reprojection
+                                      bounds=BoundingBox(*self.footprint().get_bounds(self.crs)), gcps=None)
+            else:  # for rpcs based reprojection
                 src = SimpleNamespace(width=self.width, height=self.height, transform=self.transform, crs=self.crs,
                                       rpcs=rpcs)
             dst_crs, dst_transform, dst_width, dst_height = calc_transform(
@@ -1838,7 +1841,8 @@ release, please use: .colorize('gray').to_png()", GeoRaster2Warning)
 
     def __invert__(self):
         """Invert mask."""
-        return self.copy_with(image=np.ma.masked_array(self.image.data, np.logical_not(np.ma.getmaskarray(self.image))))
+        return self.copy_with(image=np.ma.masked_array(self.image.data,
+                              np.logical_not(np.ma.getmaskarray(self.image))))
 
     def mask(self, vector, mask_shape_nodata=False):
         """

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -11,7 +11,7 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from math import ceil
 from telluric.vrt import boundless_vrt_doc
-
+from telluric.constants import WGS84_CRS
 
 def _calc_overviews_factors(one, blocksize=256):
     res = max(one.width, one.height)
@@ -208,7 +208,7 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None, rpcs=Non
 
         else:
             if rpcs is not None:
-                src_crs=src.crs
+                src_crs=WGS84_CRS #by rpcs definition
                 dst_transform, dst_width, dst_height = calcdt(
                     src_crs, dst_crs, src.width, src.height,
                     rpcs=rpcs, **kwargs)
@@ -359,11 +359,11 @@ def warp(source_file, destination_file, dst_crs=None, resolution=None, dimension
             if creation_options is not None:
                 out_kwargs.update(**creation_options)
 
+            if rpcs:
+                src_crs = WGS84_CRS #by rpcs definition
+            else:
+                src_crs = src.crs
             with rasterio.open(destination_file, 'w', **out_kwargs) as dst:
-                if rpcs:
-                    src_crs = None
-                else:
-                    src_crs = src.transform
                 reproject(
                     source=rasterio.band(src, src.indexes),
                     destination=rasterio.band(dst, dst.indexes),

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -13,6 +13,7 @@ from math import ceil
 from telluric.vrt import boundless_vrt_doc
 from telluric.constants import WGS84_CRS
 
+
 def _calc_overviews_factors(one, blocksize=256):
     res = max(one.width, one.height)
     factor = 2
@@ -208,7 +209,7 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None, rpcs=Non
 
         else:
             if rpcs is not None:
-                src_crs=WGS84_CRS #by rpcs definition
+                src_crs = WGS84_CRS  # by rpcs definition
                 dst_transform, dst_width, dst_height = calcdt(
                     src_crs, dst_crs, src.width, src.height,
                     rpcs=rpcs, **kwargs)
@@ -360,7 +361,7 @@ def warp(source_file, destination_file, dst_crs=None, resolution=None, dimension
                 out_kwargs.update(**creation_options)
 
             if rpcs:
-                src_crs = WGS84_CRS #by rpcs definition
+                src_crs = WGS84_CRS  # by rpcs definition
             else:
                 src_crs = src.crs
             with rasterio.open(destination_file, 'w', **out_kwargs) as dst:

--- a/telluric/util/raster_utils.py
+++ b/telluric/util/raster_utils.py
@@ -120,8 +120,8 @@ def convert_to_cog(source_file, destination_file, resampling=rasterio.enums.Resa
                              COPY_SRC_OVERVIEWS=True, **creation_options)
 
 
-def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
-                   src_bounds=None, dst_bounds=None, target_aligned_pixels=False):
+def calc_transform(src, dst_crs=None, resolution=None, dimensions=None, rpcs=None,
+                   src_bounds=None, dst_bounds=None, target_aligned_pixels=False, **kwargs):
     """Output dimensions and transform for a reprojection.
 
     Parameters
@@ -135,6 +135,8 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
         system.
     dimensions: tuple (width, height), optional
         Output file size in pixels and lines.
+    rpcs: RPC or dict, optional
+        Rational polynomial coefficients for the source.
     src_bounds: tuple (xmin, ymin, xmax, ymax), optional
         Georeferenced extent of output file from source bounds
         (in source georeferenced units).
@@ -144,6 +146,8 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
     target_aligned_pixels: bool, optional
         Align the output bounds based on the resolution.
         Default is `False`.
+    kwargs: optional
+        Additional arguments passed to transformation function.
 
     Returns
     -------
@@ -203,15 +207,21 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
             dst_height = max(int(ceil((ymax - ymin) / resolution[1])), 1)
 
         else:
-            if src.transform.is_identity and src.gcps:
-                src_crs = src.gcps[1]
-                kwargs = {'gcps': src.gcps[0]}
+            if rpcs is not None:
+                src_crs=src.crs
+                dst_transform, dst_width, dst_height = calcdt(
+                    src_crs, dst_crs, src.width, src.height,
+                    rpcs=rpcs, **kwargs)
             else:
-                src_crs = src.crs
-                kwargs = src.bounds._asdict()
-            dst_transform, dst_width, dst_height = calcdt(
-                src_crs, dst_crs, src.width, src.height,
-                resolution=resolution, **kwargs)
+                if src.transform.is_identity and src.gcps:
+                    src_crs = src.gcps[1]
+                    kwargs = {'gcps': src.gcps[0]}
+                else:
+                    src_crs = src.crs
+                    kwargs = src.bounds._asdict()
+                dst_transform, dst_width, dst_height = calcdt(
+                    src_crs, dst_crs, src.width, src.height,
+                    resolution=resolution, **kwargs)
 
     elif dimensions:
         # Same projection, different dimensions, calculate resolution.
@@ -260,7 +270,7 @@ def calc_transform(src, dst_crs=None, resolution=None, dimensions=None,
 
 # Code was adapted from rasterio.rio.warp module
 def warp(source_file, destination_file, dst_crs=None, resolution=None, dimensions=None,
-         src_bounds=None, dst_bounds=None, src_nodata=None, dst_nodata=None,
+         src_bounds=None, dst_bounds=None, src_nodata=None, dst_nodata=None, rpcs=None,
          target_aligned_pixels=False, check_invert_proj=True,
          creation_options=None, resampling=Resampling.cubic, **kwargs):
     """Warp a raster dataset.
@@ -288,6 +298,8 @@ def warp(source_file, destination_file, dst_crs=None, resolution=None, dimension
         Manually overridden source nodata.
     dst_nodata: int, float, or nan, optional
         Manually overridden destination nodata.
+    rpcs: RPC or dict, optional
+        Rational polynomial coefficients for the source.
     target_aligned_pixels: bool, optional
         Align the output bounds based on the resolution.
         Default is `False`.
@@ -311,8 +323,8 @@ def warp(source_file, destination_file, dst_crs=None, resolution=None, dimension
         with rasterio.open(source_file) as src:
             out_kwargs = src.profile.copy()
             dst_crs, dst_transform, dst_width, dst_height = calc_transform(
-                src, dst_crs, resolution, dimensions,
-                src_bounds, dst_bounds, target_aligned_pixels)
+                src, dst_crs, resolution, dimensions, rpcs,
+                src_bounds, dst_bounds, target_aligned_pixels, **kwargs)
 
             # If src_nodata is not None, update the dst metadata NODATA
             # value to src_nodata (will be overridden by dst_nodata if it is not None.
@@ -348,12 +360,16 @@ def warp(source_file, destination_file, dst_crs=None, resolution=None, dimension
                 out_kwargs.update(**creation_options)
 
             with rasterio.open(destination_file, 'w', **out_kwargs) as dst:
+                if rpcs:
+                    src_crs = None
+                else:
+                    src_crs = src.transform
                 reproject(
                     source=rasterio.band(src, src.indexes),
                     destination=rasterio.band(dst, dst.indexes),
-                    src_transform=src.transform,
-                    src_crs=src.crs,
+                    src_crs=src_crs,
                     src_nodata=src_nodata,
+                    rpcs=rpcs,
                     dst_transform=out_kwargs['transform'],
                     dst_crs=out_kwargs['crs'],
                     dst_nodata=dst_nodata,

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -11,6 +11,7 @@ from PIL import Image
 from shapely.geometry import Point, Polygon
 
 from rasterio.crs import CRS
+from rasterio.rpc import RPC
 from rasterio.errors import NotGeoreferencedWarning
 from rasterio.windows import Window
 from telluric.constants import WGS84_CRS, WEB_MERCATOR_CRS
@@ -33,6 +34,13 @@ some_image_3d_multiband = np.ma.array(
 raster_origin = Point(2, 3)
 some_affine = Affine.translation(raster_origin.x, raster_origin.y)
 some_crs = CRS({'init': 'epsg:32620'})
+some_rpcs = RPC(height_off=10.0, height_scale=10.0, lat_off=30.0, lat_scale=30.0,
+                line_den_coeff=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, -1.0, -2.0, -3.0, 6.0, 1.0, 2.0, 4.0, 5.0, 6.0, 7.0],
+                line_num_coeff=[2.0, 5.0, 3.0, 4.0, 5.0, 9.0, 7.0, 8.0, 9.0, 10.0, -1.0, -2.0, -3.0, 6.0, 9.0, 2.0, 3.0, 5.0, 6.0, 7.0],
+                line_off=0.0, line_scale=0.0, long_off=0.0, long_scale=0.0,
+                samp_den_coeff=[4.0, 7.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 1.0, -2.0, -3.0, 7.0, 1.0, 2.0, 7.0, 5.0, 6.0, 7.0],
+                samp_num_coeff=[8.0, 9.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 8.0, -2.0, -3.0, 6.0, 1.0, 5.0, 4.0, 5.0, 6.0, 7.0],
+                samp_off=50.0, samp_scale=50.0)
 some_raster = GeoRaster2(some_image_2d, affine=some_affine, crs=some_crs, band_names=['r'])
 some_raster_alt = GeoRaster2(some_image_2d_alt, affine=some_affine, crs=some_crs, band_names=['r'])
 some_raster_multiband = GeoRaster2(
@@ -48,15 +56,16 @@ some_raster_shrunk_mask = some_raster_multiband.copy_with(
 
 def test_construction():
     # test image - different formats yield identical rasters:
-    raster_masked_2d = GeoRaster2(some_image_2d, affine=some_affine, crs=some_crs)
-    raster_masked_3d = GeoRaster2(some_image_3d, affine=some_affine, crs=some_crs)
-    raster_masked_array = GeoRaster2(some_array, nodata=5, affine=some_affine, crs=some_crs)
+    raster_masked_2d = GeoRaster2(some_image_2d, affine=some_affine, crs=some_crs, rpcs=some_rpcs)
+    raster_masked_3d = GeoRaster2(some_image_3d, affine=some_affine, crs=some_crs, rpcs=some_rpcs)
+    raster_masked_array = GeoRaster2(some_array, nodata=5, affine=some_affine, crs=some_crs, rpcs=some_rpcs)
     assert raster_masked_2d == raster_masked_3d
     assert raster_masked_2d == raster_masked_array
 
     assert np.array_equal(raster_masked_2d.image, some_image_3d)
     assert raster_masked_2d.affine == some_affine
     assert raster_masked_2d.crs == some_crs
+    assert raster_masked_2d.rpcs == some_rpcs
     assert raster_masked_2d.dtype == some_image_2d.dtype
 
     # test bandnames:
@@ -66,6 +75,28 @@ def test_construction():
     with pytest.raises(GeoRaster2Error):
         GeoRaster2(some_image_2d, affine=some_affine, crs=some_crs, band_names=['gray', 'red'])
 
+def test_rpcs_init():
+    # test rpcs initilization by passing rpcs in different forms
+    rpcs_dict = some_rpcs.to_dict()
+    rpcs_dict = {k.upper(): v for k, v in rpcs_dict.items()}
+    georaster1 = GeoRaster2(some_image_2d, rpcs=some_rpcs)
+    georaster2 = GeoRaster2(some_image_2d, rpcs=rpcs_dict)
+    assert georaster1.rpcs == georaster2.rpcs
+    # rpcs defined as dictionary of str
+    new_rpcs_dict = {}
+    for k, v in rpcs_dict.items():
+        if isinstance(v, float):
+            new_rpcs_dict[k] = str(v)
+        line_num_coeff = rpcs_dict['LINE_NUM_COEFF']
+        new_rpcs_dict['LINE_NUM_COEFF'] = ' '.join(str(e) for e in line_num_coeff)
+        line_den_coeff = rpcs_dict['LINE_DEN_COEFF']
+        new_rpcs_dict['LINE_DEN_COEFF'] = ' '.join(str(e) for e in line_den_coeff)
+        samp_num_coeff = rpcs_dict['SAMP_NUM_COEFF']
+        new_rpcs_dict['SAMP_NUM_COEFF'] = ' '.join(str(e) for e in samp_num_coeff)
+        samp_den_coeff = rpcs_dict['SAMP_DEN_COEFF']
+        new_rpcs_dict['SAMP_DEN_COEFF'] = ' '.join(str(e) for e in samp_den_coeff)
+    georaster3 = GeoRaster2(some_image_2d, rpcs=new_rpcs_dict)
+    assert georaster2.rpcs == georaster3.rpcs
 
 def test_eq():
     """ test ._eq_ """
@@ -779,6 +810,16 @@ def test_reproject_lazy():
     assert reprojected._image is None
     assert reprojected._filename is not None
     assert reprojected._temporary
+
+
+def test_reproject_rpcs():
+    # test reprojection when rpcs are defined and input raster has no src_crs
+    # TODO: add smaller test data
+    raster = GeoRaster2.open("tests/data/raster/grayscale.tif")
+    reprojected = raster.reproject(dst_crs=WEB_MERCATOR_CRS,
+        rpcs=raster.rpcs, target_aligned_pixels=False)
+    assert reprojected.shape == (1, 2072, 5241)
+    assert reprojected.mean()[0] == pytest.approx(724.4861459505134, 1e-4)
 
 
 def test_reproject_when_having_no_data_values_in_image():

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -35,11 +35,15 @@ raster_origin = Point(2, 3)
 some_affine = Affine.translation(raster_origin.x, raster_origin.y)
 some_crs = CRS({'init': 'epsg:32620'})
 some_rpcs = RPC(height_off=10.0, height_scale=10.0, lat_off=30.0, lat_scale=30.0,
-                line_den_coeff=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, -1.0, -2.0, -3.0, 6.0, 1.0, 2.0, 4.0, 5.0, 6.0, 7.0],
-                line_num_coeff=[2.0, 5.0, 3.0, 4.0, 5.0, 9.0, 7.0, 8.0, 9.0, 10.0, -1.0, -2.0, -3.0, 6.0, 9.0, 2.0, 3.0, 5.0, 6.0, 7.0],
+                line_den_coeff=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+                                -1.0, -2.0, -3.0, 6.0, 1.0, 2.0, 4.0, 5.0, 6.0, 7.0],
+                line_num_coeff=[2.0, 5.0, 3.0, 4.0, 5.0, 9.0, 7.0, 8.0, 9.0, 10.0, -1.0,
+                                -2.0, -3.0, 6.0, 9.0, 2.0, 3.0, 5.0, 6.0, 7.0],
                 line_off=0.0, line_scale=0.0, long_off=0.0, long_scale=0.0,
-                samp_den_coeff=[4.0, 7.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 1.0, -2.0, -3.0, 7.0, 1.0, 2.0, 7.0, 5.0, 6.0, 7.0],
-                samp_num_coeff=[8.0, 9.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 8.0, -2.0, -3.0, 6.0, 1.0, 5.0, 4.0, 5.0, 6.0, 7.0],
+                samp_den_coeff=[4.0, 7.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 1.0,
+                                -2.0, -3.0, 7.0, 1.0, 2.0, 7.0, 5.0, 6.0, 7.0],
+                samp_num_coeff=[8.0, 9.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0,
+                                8.0, -2.0, -3.0, 6.0, 1.0, 5.0, 4.0, 5.0, 6.0, 7.0],
                 samp_off=50.0, samp_scale=50.0)
 some_raster = GeoRaster2(some_image_2d, affine=some_affine, crs=some_crs, band_names=['r'])
 some_raster_alt = GeoRaster2(some_image_2d_alt, affine=some_affine, crs=some_crs, band_names=['r'])
@@ -75,6 +79,7 @@ def test_construction():
     with pytest.raises(GeoRaster2Error):
         GeoRaster2(some_image_2d, affine=some_affine, crs=some_crs, band_names=['gray', 'red'])
 
+
 def test_rpcs_init():
     # test rpcs initilization by passing rpcs in different forms
     rpcs_dict = some_rpcs.to_dict()
@@ -97,6 +102,7 @@ def test_rpcs_init():
         new_rpcs_dict['SAMP_DEN_COEFF'] = ' '.join(str(e) for e in samp_den_coeff)
     georaster3 = GeoRaster2(some_image_2d, rpcs=new_rpcs_dict)
     assert georaster2.rpcs == georaster3.rpcs
+
 
 def test_eq():
     """ test ._eq_ """
@@ -817,7 +823,7 @@ def test_reproject_rpcs():
     # TODO: add smaller test data
     raster = GeoRaster2.open("tests/data/raster/grayscale.tif")
     reprojected = raster.reproject(dst_crs=WEB_MERCATOR_CRS,
-        rpcs=raster.rpcs, target_aligned_pixels=False)
+                                   rpcs=raster.rpcs)
     assert reprojected.shape == (1, 2072, 5241)
     assert reprojected.mean()[0] == pytest.approx(724.4861459505134, 1e-4)
 
@@ -828,7 +834,7 @@ def test_reproject_when_having_no_data_values_in_image():
     for i in range(500):
         for j in range(500):
             if j % 2 == 0:
-                arr[0,  i, j] = 300
+                arr[0, i, j] = 300
     arr = np.ma.masked_array(arr, arr == 1)
     raster = make_test_raster(image=arr)
     reprojected_raster = raster.reproject(WGS84_CRS, resampling=Resampling.average)
@@ -969,7 +975,7 @@ def test_doesnt_use_mask_when_no_mask():
 
 
 def rasters_for_testing_chunks():
-    rasters = [GeoRaster2.open("tests/data/raster/overlap2.tif"),  GeoRaster2.open("tests/data/raster/overlap2.tif")]
+    rasters = [GeoRaster2.open("tests/data/raster/overlap2.tif"), GeoRaster2.open("tests/data/raster/overlap2.tif")]
     rasters[0].image
     return rasters
 


### PR DESCRIPTION
## Proposed changes 

Linked to #316

- rpcs initialization in constructor (rpcs can be specified in 3 different ways and are stored in a rasterio.rpc.RPC object)
- added property method to access rpcs
- improved save method to save rasters with rpcs
- improved reprojection. Reprojection now supports rpcs and the use of the DEM (passed as kwarg)
- added unit tests for constructor, reprojection

