### PR TITLE
Don't raise an exception while calling GeoRaster2.rpcs

### DIFF
--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -764,6 +764,8 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
 
             if self._rpcs is None:
                 self._rpcs = copy(raster.rpcs)
+                if self._rpcs is None:
+                    self._rpcs = ""
 
             # if band_names not provided, try read them from raster tags.
             # if not - leave empty, for default:
@@ -843,7 +845,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         """Raster rpcs."""
         if self._rpcs is None:
             self._populate_from_rasterio_object(read_image=False)
-        return self._rpcs
+        return self._rpcs if self._rpcs != "" else None
 
     @property
     def shape(self):

--- a/tests/test_georaster.py
+++ b/tests/test_georaster.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory, NamedTemporaryFile
 from copy import deepcopy
 
 import numpy as np
+import rasterio.shutil
 from affine import Affine
 from rasterio.enums import Resampling, MaskFlags
 from unittest.mock import Mock
@@ -826,6 +827,20 @@ def test_reproject_rpcs():
                                    rpcs=raster.rpcs)
     assert reprojected.shape == (1, 2072, 5241)
     assert reprojected.mean()[0] == pytest.approx(724.4861459505134, 1e-4)
+
+
+def test_no_error_empty_rpcs():
+    # Make sure that calling rpcs method doesn't raise an exception
+    # if the underlying file was deleted and the instance was created
+    # with lazy_load=False.
+    path = "/vsimem/raster_for_test.tif"
+    some_raster.save(path)
+    raster = GeoRaster2.open(path, lazy_load=False)
+    assert raster.rpcs is None
+
+    rasterio.shutil.delete(path)
+    assert not rasterio.shutil.exists(path)
+    assert raster.rpcs is None
 
 
 def test_reproject_when_having_no_data_values_in_image():


### PR DESCRIPTION
Make sure that calling `rpcs` method doesn't raise an exception if the underlying file was deleted and the instance was created with `lazy_load=False`.