### PR TITLE
Enable with statement & explicit cleanup

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,9 @@
+telluric 0.14.3 (2022-12-21)
+============================
+
+* New `telluric.georaster.GeoRaster2.cleanup` method to explicitly release internal resources.
+* Support to open `telluric.georaster.GeoRaster2` with `with` statement to encapsulate common preparation and cleanup.
+
 telluric 0.14.2 (2022-11-17)
 ============================
 

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -740,10 +740,10 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                                        dtype=dtype, shape=shape, ul_corner=ul_corner, raster_cls=cls)
 
     def _cleanup(self):
-        for f in self._opened_files:
-            f.close()
-
-        self._opened_files = []
+        if self._opened_files:
+            for f in list(self._opened_files):
+                f.close()
+                self._opened_files.pop(0)
 
         if self._filename is not None and self._temporary:
             with contextlib.suppress(FileNotFoundError):

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -628,6 +628,12 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         self._rpcs = self._read_rpcs(rpcs)
         self._opened_files = []
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type=None, exc_val=None, exc_tb=None):
+        self.__del__()
+
     def __del__(self):
         try:
             self._cleanup()
@@ -736,11 +742,19 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
     def _cleanup(self):
         for f in self._opened_files:
             f.close()
+
+        self._opened_files = []
+
         if self._filename is not None and self._temporary:
             with contextlib.suppress(FileNotFoundError):
                 os.remove(self._filename)
             self._filename = None
             self._temporary = False
+
+    @classmethod
+    def cleanup(cls):
+        """Release internal resources."""
+        cls._cleanup()
 
     def _populate_from_rasterio_object(self, read_image):
         # if there is no _filename we have nowhere to populate from.

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -746,8 +746,13 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
                 self._opened_files.pop(0)
 
         if self._filename is not None and self._temporary:
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(self._filename)
+            with contextlib.suppress(OSError):
+                try:
+                    if os.path.exists(self._filename):
+                        os.remove(self._filename)
+                except Exception:
+                    pass
+
             self._filename = None
             self._temporary = False
 


### PR DESCRIPTION
This simple PR add support to open `GeoRaster2` using `with` statement:

```
with GeoRaster2.open(file_name, ...) as raster:
     # ...
     # ...
```
