### PR TITLE
Replace Stamen tiles + fix other deprecations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
             'coverage',
             'mypy',
             'types-python-dateutil',
-            'types-pkg_resources',
             'packaging',
             'pycodestyle',
             'pytest>=4',

--- a/telluric/base_vrt.py
+++ b/telluric/base_vrt.py
@@ -1,5 +1,6 @@
 """Base VRT class and fuctions."""
 
+import importlib.resources
 import lxml.etree as ET
 
 from xml.dom import minidom
@@ -8,8 +9,6 @@ try:
     from rasterio._path import _parse_path, _vsi_path
 except ImportError:
     from rasterio.path import parse_path as _parse_path, vsi_path as _vsi_path
-
-from pkg_resources import resource_filename
 
 
 def prettify(elem):
@@ -21,9 +20,11 @@ def prettify(elem):
 
 
 def load_scheme():
-    with open(resource_filename('telluric', 'gdalvrt.xsd')) as f:
-        scheme_doc = ET.parse(f)
-        return ET.XMLSchema(scheme_doc)
+    ref = importlib.resources.files('telluric') / 'gdalvrt.xsd'
+    with importlib.resources.as_file(ref) as path:
+        with path.open() as f:
+            scheme_doc = ET.parse(f)
+            return ET.XMLSchema(scheme_doc)
 
 
 class BaseVRT:

--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -16,6 +16,7 @@ from rasterio.crs import CRS
 from shapely.prepared import prep
 
 from telluric.constants import WEB_MERCATOR_CRS, WGS84_CRS
+from telluric.util.general import as_crs
 from telluric.vectors import GeoVector
 from telluric.features import GeoFeature
 from telluric.plotting import NotebookPlottingMixin
@@ -532,7 +533,7 @@ class FileCollection(BaseCollection):
         """
         with fiona.Env():
             with fiona.open(filename, 'r') as source:
-                original_crs = CRS(source.crs)
+                original_crs = as_crs(source.crs)
                 schema = source.schema
                 length = len(source)
         crs = crs or original_crs

--- a/telluric/collections.py
+++ b/telluric/collections.py
@@ -325,9 +325,11 @@ class BaseCollection(Sequence, NotebookPlottingMixin):
             crs = self.crs
 
         # https://github.com/rasterio/rasterio/issues/2453
-        crs = crs.to_dict()
+        # https://github.com/rasterio/rasterio/issues/3282 (to_dict() is lossy in rasterio)
+        # We should switch to fiona 1.9.x and convert to fiona.crs.CRS
+        crs_wkt = crs.to_wkt()
 
-        with fiona.open(filename, 'w', driver=driver, schema=schema, crs=crs) as sink:
+        with fiona.open(filename, 'w', driver=driver, schema=schema, crs_wkt=crs_wkt) as sink:
             for feature in self:
                 new_feature = self._adapt_feature_before_write(feature)
                 sink.write(new_feature.to_record(crs))

--- a/telluric/georaster.py
+++ b/telluric/georaster.py
@@ -47,6 +47,7 @@ from shapely.geometry import Point, Polygon
 from PIL import Image
 
 from telluric.constants import WEB_MERCATOR_CRS, MERCATOR_RESOLUTION_MAPPING, RASTER_TYPE, WGS84_CRS
+from telluric.util.general import as_crs
 from telluric.vectors import GeoVector
 from telluric.util.projections import transform
 from telluric.util.raster_utils import (
@@ -620,7 +621,7 @@ class GeoRaster2(WindowMethodsMixin, _Raster):
         """
         super().__init__(image=image, band_names=band_names, shape=shape, nodata=nodata)
         self._affine = deepcopy(affine)
-        self._crs = None if crs is None else CRS(crs)  # type: Union[None, CRS]
+        self._crs = None if crs is None else as_crs(crs)  # type: Union[None, CRS]
         self._filename = filename
         self._temporary = temporary
         self._footprint = copy(footprint)

--- a/telluric/plotting.py
+++ b/telluric/plotting.py
@@ -51,7 +51,7 @@ def simple_plot(feature, *, mp=None, **map_kwargs):
     from telluric.collections import BaseCollection
 
     if mp is None:
-        mp = folium.Map(tiles="Stamen Terrain", **map_kwargs)
+        mp = folium.Map(tiles="CartoDB Positron", **map_kwargs)
 
     if feature.is_empty:
         warnings.warn("The geometry is empty.")
@@ -143,7 +143,7 @@ def plot(feature, mp=None, style_function=None, **map_kwargs):
         Extra parameters to send to ipyleaflet.Map.
 
     """
-    map_kwargs.setdefault('basemap', basemaps.Stamen.Terrain)
+    map_kwargs.setdefault('basemap', basemaps.CartoDB.Positron)
     if feature.is_empty:
         warnings.warn("The geometry is empty.")
         mp = Map(**map_kwargs) if mp is None else mp

--- a/telluric/util/general.py
+++ b/telluric/util/general.py
@@ -1,4 +1,5 @@
 import numpy as np
+from rasterio.crs import CRS
 
 
 def convert_meter_to_latlon_deg(lat_deg):
@@ -14,3 +15,7 @@ def convert_resolution_from_meters_to_deg(position_lat, gsd_metric):
     gsd_deg_lat = gsd_metric * m_to_deg_lat
     gsd_deg_lon = gsd_metric * m_to_deg_lon
     return gsd_deg_lon, gsd_deg_lat
+
+
+def as_crs(crs) -> CRS:
+    return crs if isinstance(crs, CRS) else CRS(crs)

--- a/telluric/util/local_tile_server.py
+++ b/telluric/util/local_tile_server.py
@@ -116,7 +116,7 @@ class TileServer:
 
     @classmethod
     def folium_client(cls, obj, bounds, mp=None, capture=None,
-                      base_map_name="Stamen Terrain", port=None):
+                      base_map_name="CartoDB Positron", port=None):
         port = port or cls.default_port()
         shape = bounds.get_shape(WGS84_CRS)
         mp = mp or folium.Map(tiles=base_map_name)

--- a/telluric/vectors.py
+++ b/telluric/vectors.py
@@ -17,6 +17,7 @@ from rasterio._err import CPLE_AppDefinedError
 from typing import Tuple, Iterator
 
 from telluric.constants import DEFAULT_CRS, EQUAL_AREA_CRS, WGS84_CRS, WEB_MERCATOR_CRS
+from telluric.util.general import as_crs
 from telluric.util.projections import transform
 from telluric.plotting import NotebookPlottingMixin
 
@@ -289,7 +290,7 @@ class GeoVector(_GeoVectorDelegator, NotebookPlottingMixin):
 
         """
         self._shape = shape  # type: shapely.geometry.base.BaseGeometry
-        self._crs = CRS(crs)
+        self._crs = as_crs(crs)
 
     @classmethod
     def from_geojson(cls, filename):

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -362,7 +362,7 @@ def test_feature_collection_with_dates_serializes_correctly():
     with tempfile.TemporaryDirectory() as path:
         file_path = os.path.join(path, "test_dates.shp")
         with fiona.open(
-            file_path, mode='w', driver="ESRI Shapefile", schema=schema, crs=feature.crs.to_dict()
+            file_path, mode='w', driver="ESRI Shapefile", schema=schema, crs_wkt=feature.crs.to_wkt()
         ) as sink:
             sink.write(mapping(feature))
 


### PR DESCRIPTION
Resolves #329 

This PR is for making telluric work with more up-to-date versions python and packages.

Changes included so far:

1. Use `CartoDB` refernce maps instead of `Stamen` (which are not available any more - see  [folium #1803](https://github.com/python-visualization/folium/issues/1803)
2. Remove dependency on  deprecated `pkg_resources`  (not required for Python>=3.7)
3. Fix some failing tests and linters
